### PR TITLE
feat: add weather analysis provenance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
   an earlier value while keeping identical repeated records idempotent.
 - Added executable and static contracts for conflict detection and
   pre-mutation ordering.
+- Added NOAA source, normalized station, inclusive historical range, and UTC
+  retrieval completion time to the average-temperature plot title.
+- Added explicit observation-date and Fahrenheit axis labels plus deterministic
+  provenance validation in the offline synthetic plot flow.
 
 ## 2026-06-14
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-18
 
+- Explicitly rejected NOAA 3xx responses before parsing JSON; Requests does
+  not treat redirects as errors in `raise_for_status()`.
+- Treated JSON boolean observation values as malformed instead of converting
+  them to numeric weather measurements.
 - Updated both hashed Python lockfiles to `jupyter-server` 2.20.0 to remediate
   CVE-2026-44727 while preserving the existing direct dependency set.
 - Added a fail-closed contract for the reviewed transitive security pin and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-18
+
+- Updated both hashed Python lockfiles to `jupyter-server` 2.20.0 to remediate
+  CVE-2026-44727 while preserving the existing direct dependency set.
+- Added a fail-closed contract for the reviewed transitive security pin and
+  refreshed both lockfile integrity digests.
+
 ## 2026-06-16
 
 - Rejected NOAA result-count drift across paginated responses before later

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-16
 
+- Rejected NOAA result-count drift across paginated responses before later
+  observations can alter the accumulated analysis.
 - Rejected conflicting duplicate NOAA observations before they can overwrite
   an earlier value while keeping identical repeated records idempotent.
 - Added executable and static contracts for conflict detection and

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   your local environment and out of git; blank or whitespace-only values are
   rejected before requests are made. The reusable fetch helper also rejects
   invalid years, datatypes, and station identifiers before network use.
+- NOAA result counts must remain stable across paginated responses; count drift
+  fails before a later page can alter the accumulated analysis.
 - Do not commit NOAA API tokens, private datasets, or refreshed outputs without source dates.
 
 ## Security and Privacy Notes
@@ -143,6 +145,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   offline dataframe and plotting coverage.
 - See `docs/plans/2026-06-16-weather-analysis-provenance.md` for station,
   historical range, UTC retrieval-time, and display-unit plot context.
+- See `docs/plans/2026-06-16-stable-noaa-result-count.md` for fail-closed
+  pagination count consistency.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,18 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 
 - Run `jupyter notebook Weather.ipynb` after installing dependencies and setting `NOAA_TOKEN`.
 - The notebook fetches NOAA CDO observations for station `GHCND:US1CAMR0037` across the configured date range.
+- The station is the repository's original sample selection, and the fixed
+  2019 range keeps the analysis bounded and historical. Neither is claimed as
+  a representative climate series or current-weather source.
 - NOAA requests explicitly use metric units; Celsius temperatures and
   millimeter precipitation are converted for Fahrenheit/inch presentation.
 - Token-bearing NOAA requests do not follow redirects, keeping credentials on
   the configured Climate Data Online API origin.
 - NOAA result sets are fetched in 1,000-row pages with a 20-page safety limit
   per request group; exhausting the limit raises instead of silently truncating.
+- The average-temperature plot identifies NOAA CDO, the station, inclusive
+  observation range, UTC retrieval completion time, and Fahrenheit display
+  units so exported screenshots retain their analysis context.
 
 ## Testing and Verification
 
@@ -71,7 +77,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - `python3 -m unittest weather_notebook_tests` runs the executable NOAA helper
   tests plus an offline synthetic flow through fake responses, date bucketing,
   converted pandas rows, and a headless matplotlib line plot without a token or
-  network request.
+  network request. The synthetic plot also verifies deterministic provenance
+  title and axis labels.
 - `make lock` regenerates reviewed Python 3.12 and 3.14 Linux lockfiles with
   SHA-256 hashes from the five direct pins in `requirements.txt`.
 - Hosted installs use pip `--require-hashes` against the matrix-matched lock;
@@ -134,6 +141,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   NOAA token on the configured API origin.
 - See `docs/plans/2026-06-14-synthetic-analysis-flow.md` for deterministic
   offline dataframe and plotting coverage.
+- See `docs/plans/2026-06-16-weather-analysis-provenance.md` for station,
+  historical range, UTC retrieval-time, and display-unit plot context.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,3 +69,5 @@ Good-faith research is welcome when it stays within these boundaries:
 ## Maintainer Response
 
 The maintainer will review complete reports as availability allows, prioritize issues by exploitability and impact, and coordinate a fix or mitigation when the affected code is still maintained. For sample, archived, or educational repositories, the likely remediation may be documentation, dependency updates, or clearly marking unsupported code rather than a production-style patch release.
+NOAA result-count changes fail before later pages are accumulated, preventing
+one analysis from silently combining inconsistent pagination snapshots.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,9 @@ requested record before page results are accumulated.
 Token-bearing NOAA requests must not follow redirects; redirect responses are
 rejected before response bodies are parsed so the provider-specific `token`
 header stays on the configured API origin.
+Generated analysis plots should retain NOAA source, station, observation range,
+UTC retrieval completion time, and display units. This context reduces the risk
+that a historical sample is redistributed as current or representative data.
 
 ## Dependency and Supply Chain Security
 

--- a/VISION.md
+++ b/VISION.md
@@ -23,6 +23,7 @@ Priority:
 - Validate NOAA result shapes before converting observations
 - Fetch complete NOAA result pages within an explicit request safety bound
 - Validate returned NOAA page offsets before accumulating observations
+- Reject NOAA result-count drift across paginated responses
 - Reject conflicting duplicate NOAA observations before dataframe construction
 - Raise explicit errors for unexpected NOAA response roots
 - Reject non-text NOAA observation date and datatype keys before bucketing

--- a/VISION.md
+++ b/VISION.md
@@ -35,12 +35,12 @@ Priority:
 - Keep the scientific environment exactly pinned and import-verified in CI
 - Exercise the complete offline analysis flow from synthetic NOAA responses
   through dataframe construction and a headless average-temperature plot
+- Include NOAA source, station, historical range, UTC retrieval completion
+  time, and display units in generated plot context
 
 Next priorities:
 
 - Add README setup notes and dependency requirements
-- Document station and date-range choices
-- Add data-source timestamps to generated outputs
 
 Contribution rules:
 

--- a/Weather.ipynb
+++ b/Weather.ipynb
@@ -16,11 +16,13 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "from datetime import datetime, timezone\n",
     "\n",
     "# store the data we get as a dataframe\n",
     "import pandas as pd\n",
     "\n",
     "from weather_notebook import build_weather_rows, fetch_noaa_data, record_observation\n",
+    "from weather_notebook import format_analysis_provenance\n",
     "\n",
     "# load the access token you got from NOAA from the local environment\n",
     "token = os.environ.get(\"NOAA_TOKEN\", \"\").strip()\n",
@@ -49,7 +51,9 @@
     "    prcp_results = fetch_noaa_data(year, [\"TMIN\", \"PRCP\"], token, STATION_ID)\n",
     "\n",
     "    for item in temp_results + prcp_results:\n",
-    "        record_observation(item, weather_by_date)\n"
+    "        record_observation(item, weather_by_date)\n",
+    "\n",
+    "RETRIEVED_AT = datetime.now(timezone.utc)\n"
    ]
   },
   {
@@ -65,7 +69,12 @@
     "\n",
     "df_temp.head()\n",
     "\n",
-    "df_temp.plot(kind=\"line\", x=\"date\", y=\"avgTemp\")\n"
+    "axes = df_temp.plot(kind=\"line\", x=\"date\", y=\"avgTemp\")\n",
+    "axes.set_title(format_analysis_provenance(\n",
+    "    STATION_ID, START_YEAR, END_YEAR_EXCLUSIVE, RETRIEVED_AT\n",
+    "))\n",
+    "axes.set_xlabel(\"Observation date\")\n",
+    "axes.set_ylabel(\"Average temperature (degrees F)\")\n"
    ]
   }
  ],

--- a/docs/plans/2026-06-09-weather-notebook-value-guards.md
+++ b/docs/plans/2026-06-09-weather-notebook-value-guards.md
@@ -21,7 +21,8 @@ malformed API row should not crash the whole exploratory analysis.
 ## Work Completed
 
 - Added `parse_noaa_date` to return `None` for malformed timestamps.
-- Added `noaa_number` to return `None` for missing or non-numeric values.
+- Added `noaa_number` to return `None` for missing, boolean, or non-numeric
+  values.
 - Updated temperature and precipitation conversion helpers to use guarded
   numeric conversion.
 - Skipped rows with invalid dates before building the dataframe.

--- a/docs/plans/2026-06-13-noaa-token-redirect-boundary.md
+++ b/docs/plans/2026-06-13-noaa-token-redirect-boundary.md
@@ -38,15 +38,17 @@ Primary references:
 ## Implementation
 
 1. Pass `allow_redirects=False` to the injected request function.
-2. Keep `raise_for_status()` before `response.json()` so 3xx responses fail
-   without payload processing.
+2. Keep `raise_for_status()` for 4xx/5xx responses and explicitly require a
+   2xx status before `response.json()`, because Requests does not raise for
+   3xx responses.
 3. Extend runtime fakes, offline contracts, maintenance documentation, and
    hostile mutations without adding dependencies or making a live NOAA call.
 
 ## Verification
 
-- Four focused runtime tests passed for redirect disabling, normalized request
-  options, HTTP failure propagation, and fail-before-JSON ordering.
+- Focused runtime tests cover redirect disabling, normalized request options,
+  HTTP failure propagation, real 3xx status handling, and fail-before-JSON
+  ordering.
 - All 17 executable helper tests passed.
 - Four hostile mutations covering option removal, redirect re-enablement,
   reversed status/JSON ordering, and missing runtime coverage were rejected.

--- a/docs/plans/2026-06-16-stable-noaa-result-count.md
+++ b/docs/plans/2026-06-16-stable-noaa-result-count.md
@@ -1,0 +1,56 @@
+# Require Stable NOAA Result Counts Across Pages
+
+## Status: Planned
+
+## Context
+
+`fetch_noaa_data` validates each NOAA result count independently but does not
+require the count to remain stable across pages. If result-set metadata changes
+during one paginated fetch, the notebook can combine pages from different
+logical snapshots or stop against a later count without detecting drift.
+
+## Requirements
+
+- Pin the first reported NOAA result count for a paginated request.
+- Reject any later non-null result count that differs before appending that
+  page's observations.
+- Preserve offset validation, no-progress detection, page limits, redirect
+  blocking, exact token handling, and metadata-optional fallback behavior.
+- Accept stable result counts and requests whose every page omits metadata.
+- Add runtime and mutation-sensitive static coverage plus maintained guidance.
+- Keep the notebook delegation contract unchanged.
+
+## Implementation Units
+
+### U1. Stabilize pagination metadata
+
+- **Files:** `weather_notebook.py`
+- Track the expected result count and fail before accumulation when later
+  metadata disagrees.
+
+### U2. Add deterministic regressions
+
+- **Files:** `weather_notebook_tests.py`,
+  `scripts/check_weather_notebook_contracts.py`
+- Cover stable counts, increasing/decreasing drift, pre-mutation failure,
+  metadata omission, checker registration, and plan evidence.
+
+### U3. Maintain analysis guidance
+
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Document fail-closed pagination metadata consistency.
+
+## Verification
+
+- Run focused unit/static contracts and repository/external-directory
+  non-cleaning `make verify` gates with explicit timeouts.
+- Reject mutations that remove count pinning, compare after accumulation,
+  accept drift, break metadata omission, unregister coverage, weaken guidance,
+  or reopen the plan.
+- Audit the exact diff, generated artifacts, conflicts, file modes, and
+  credential-like additions before committing.
+
+## Runtime Boundary
+
+No live NOAA token or request is used. Deterministic fake responses verify the
+client contract; NOAA service-side consistency remains external.

--- a/docs/plans/2026-06-16-stable-noaa-result-count.md
+++ b/docs/plans/2026-06-16-stable-noaa-result-count.md
@@ -1,6 +1,6 @@
 # Require Stable NOAA Result Counts Across Pages
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -54,3 +54,27 @@ logical snapshots or stop against a later count without detecting drift.
 
 No live NOAA token or request is used. Deterministic fake responses verify the
 client contract; NOAA service-side consistency remains external.
+
+## Work Completed
+
+- Pinned the first reported NOAA result count and rejected later non-null count
+  drift before accumulating the affected page.
+- Preserved metadata-optional pagination, including later pages that omit
+  metadata after a count has been established.
+- Added focused runtime regressions, mutation-sensitive static contracts, and
+  maintained user, security, roadmap, and change guidance.
+
+## Verification Completed
+
+- Four focused pagination tests passed, covering increasing and decreasing
+  drift, stable metadata, and later metadata omission.
+- The complete 26-test `weather_notebook_tests` suite passed.
+- `py_compile` passed for the runtime module, tests, and static checker.
+- The repository and external-directory non-cleaning `make verify` payloads
+  each passed with 26 runtime tests and 20 static contracts. The broad-cleaning
+  `make check` wrapper is not run because workspace policy forbids broad
+  generated-artifact deletion; its verification payload is `make verify`.
+- Eight isolated mutations were rejected for removed pinning, inverted drift
+  comparison, post-accumulation validation, missing runtime coverage, missing
+  checker registration, weakened guidance, reopened plan status, and rejected
+  later-page metadata omission.

--- a/docs/plans/2026-06-16-weather-analysis-provenance.md
+++ b/docs/plans/2026-06-16-weather-analysis-provenance.md
@@ -1,6 +1,6 @@
 # Weather Analysis Provenance
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -52,3 +52,26 @@ validation, UTC normalization, and inclusive range formatting.
 - Do not change dependencies, lockfiles, workflows, request parameters, token
   handling, pagination, unit conversion, or dataframe columns.
 - Do not merge or close stacked pull requests without explicit authorization.
+
+## Work Completed
+
+- Added validated NOAA source, normalized station, inclusive date range, and
+  second-precision UTC retrieval-time formatting.
+- Captured retrieval completion after NOAA collection and applied the
+  provenance title plus explicit observation-date and Fahrenheit axis labels.
+- Extended the offline synthetic plot and static contracts for deterministic
+  metadata, notebook ordering, documentation, and roadmap completion.
+
+## Verification Results
+
+- All 24 executable tests passed, including formatter validation and the
+  synthetic dataframe/plot flow.
+- Nine isolated hostile mutations were rejected: missing source, station
+  normalization, UTC conversion, timezone validation, inclusive end year,
+  notebook timestamp, title, x label, and y label.
+- Repository and external-directory `make check` gates each passed all 24
+  executable tests and 19 static contracts.
+- The internal package index did not expose the lock-pinned `ipykernel==7.3.0`,
+  so a fresh local hash-lock install could not complete. The checked-in locks
+  were unchanged; exact hosted matrix installation remains required.
+- No live NOAA request was made and the notebook remains output-free.

--- a/docs/plans/2026-06-16-weather-analysis-provenance.md
+++ b/docs/plans/2026-06-16-weather-analysis-provenance.md
@@ -1,0 +1,54 @@
+# Weather Analysis Provenance
+
+## Status: Planned
+
+## Context
+
+The notebook plots average temperature without identifying its NOAA source,
+station, historical date range, display units, or retrieval time. A screenshot
+or exported figure can therefore lose the context needed to distinguish this
+fixed 2019 sample from current conditions or another station's observations.
+
+## Requirements
+
+- Add a reusable formatter for NOAA analysis provenance containing the data
+  source, normalized station ID, inclusive observation range, and UTC retrieval
+  completion timestamp.
+- Reject blank station IDs, invalid year bounds, non-datetime timestamps, and
+  timezone-naive timestamps instead of emitting ambiguous labels.
+- Normalize aware timestamps to second-precision UTC with a `Z` suffix.
+- Capture retrieval completion time after NOAA collection and apply the
+  provenance string as the plot title.
+- Label the plot axes as observation date and average temperature in degrees
+  Fahrenheit.
+- Extend the offline synthetic flow to assert the exact title, labels, and
+  deterministic timestamp formatting without a token or network call.
+- Document why the sample uses station `GHCND:US1CAMR0037` and the fixed 2019
+  historical range, without claiming representativeness or current conditions.
+- Preserve output-free, token-free notebook JSON and all existing request,
+  conversion, dataframe, and plotting behavior.
+
+## Key Decision
+
+Keep provenance formatting in `weather_notebook.py` and inject an aware
+`datetime` so executable tests remain deterministic. The notebook owns the
+actual `datetime.now(timezone.utc)` call after data collection; the helper owns
+validation, UTC normalization, and inclusive range formatting.
+
+## Verification Plan
+
+- Run focused formatter and synthetic plot tests.
+- Run hostile mutations for missing source/station/range/timestamp, naive-time
+  acceptance, wrong UTC normalization, missing title, and missing unit labels.
+- Run bounded repository and external-directory `make check` gates with the
+  pinned Python 3.12 lock environment.
+- Audit notebook JSON and outputs, exact diff, generated artifacts, whitespace,
+  file modes, and changed lines for credential material.
+
+## Scope Boundaries
+
+- Do not fetch live NOAA data, change station/date defaults, refresh datasets,
+  save figures, or commit notebook outputs or execution counts.
+- Do not change dependencies, lockfiles, workflows, request parameters, token
+  handling, pagination, unit conversion, or dataframe columns.
+- Do not merge or close stacked pull requests without explicit authorization.

--- a/docs/plans/2026-06-18-jupyter-server-security-update.md
+++ b/docs/plans/2026-06-18-jupyter-server-security-update.md
@@ -1,0 +1,40 @@
+# Update the Jupyter Server Security Pin
+
+## Status: Completed
+
+## Context
+
+The reviewed Python 3.12 and 3.14 lockfiles pinned `jupyter-server` 2.19.0.
+Dependency auditing reports CVE-2026-44727 for that release and identifies
+2.20.0 as the fixed version.
+
+## Requirements
+
+- Update both hashed lockfiles to `jupyter-server` 2.20.0 from public PyPI.
+- Preserve every direct dependency version and all other transitive versions.
+- Refresh the reviewed lockfile SHA-256 values.
+- Require the fixed transitive version in the repository contract checker.
+- Run `make check` from the repository and an external working directory.
+- Install the Python 3.12 lock with hash enforcement and rerun dependency
+  auditing without a live NOAA token or request.
+
+## Work Completed
+
+- Regenerated both lockfiles with a targeted `jupyter-server` upgrade.
+- Updated only the affected version and artifact hashes in each lockfile.
+- Refreshed the fail-closed lock digests and added an explicit security-pin
+  assertion for both supported Python lockfiles.
+
+## Verification Completed
+
+- The Python 3.12 lock installed successfully with `--require-hashes`.
+- Repository and external-directory `make check` passed with 26 unit tests and
+  20 static contract groups.
+- `pip check` reported no broken requirements.
+- `pip-audit` reported no known vulnerabilities after the update.
+- The exact diff passed whitespace, artifact, and credential-pattern audits.
+
+## Runtime Boundary
+
+Validation used deterministic fake NOAA responses. No NOAA credential or live
+provider request was used.

--- a/requirements-py312.lock
+++ b/requirements-py312.lock
@@ -593,9 +593,9 @@ jupyter-lsp==2.3.1 \
     --hash=sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81 \
     --hash=sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6
     # via jupyterlab
-jupyter-server==2.19.0 \
-    --hash=sha256:1731236bc32b680223e1ceb9d68209a845203475012ef68773a81434b46a31a7 \
-    --hash=sha256:cb76591b76d7093584c2ad2ae72ac3d58614a4b597507a1bb04e1f9f683cf9ea
+jupyter-server==2.20.0 \
+    --hash=sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14 \
+    --hash=sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc
     # via
     #   jupyter-lsp
     #   jupyterlab

--- a/requirements-py314.lock
+++ b/requirements-py314.lock
@@ -593,9 +593,9 @@ jupyter-lsp==2.3.1 \
     --hash=sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81 \
     --hash=sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6
     # via jupyterlab
-jupyter-server==2.19.0 \
-    --hash=sha256:1731236bc32b680223e1ceb9d68209a845203475012ef68773a81434b46a31a7 \
-    --hash=sha256:cb76591b76d7093584c2ad2ae72ac3d58614a4b597507a1bb04e1f9f683cf9ea
+jupyter-server==2.20.0 \
+    --hash=sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14 \
+    --hash=sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc
     # via
     #   jupyter-lsp
     #   jupyterlab

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -61,6 +61,9 @@ SYNTHETIC_ANALYSIS_PLAN_PATH = (
 CONFLICTING_OBSERVATION_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-16-conflicting-noaa-observations.md"
 )
+ANALYSIS_PROVENANCE_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-16-weather-analysis-provenance.md"
+)
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "check.yml"
 LOCKFILE_SHA256 = {
     "requirements-py312.lock": "47835a6609db0175be86dd3054e5e2334668b35cf0d0d59e45208ef2fc716179",
@@ -497,6 +500,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(MAKE_ROOT_PROTECTION_PLAN_PATH, "Make root override protection")
     assert_completed_plan(SYNTHETIC_ANALYSIS_PLAN_PATH, "synthetic analysis flow")
     assert_completed_plan(CONFLICTING_OBSERVATION_PLAN_PATH, "conflicting NOAA observations")
+    assert_completed_plan(ANALYSIS_PROVENANCE_PLAN_PATH, "weather analysis provenance")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_synthetic_analysis_flow_is_exercised," in checker_main,
@@ -543,6 +547,60 @@ def test_synthetic_analysis_flow_is_exercised():
         "offline synthetic NOAA analysis-flow coverage" in changes,
         "CHANGES must record synthetic analysis coverage",
     )
+
+
+def test_analysis_provenance_is_visible_and_deterministic():
+    runtime = RUNTIME_MODULE.read_text()
+    tests = RUNTIME_TESTS.read_text()
+    notebook = notebook_source(load_notebook())
+    readme = " ".join((ROOT / "README.md").read_text().split())
+    security = " ".join((ROOT / "SECURITY.md").read_text().split())
+    vision = " ".join((ROOT / "VISION.md").read_text().split())
+    changes = " ".join((ROOT / "CHANGES.md").read_text().split())
+
+    for contract in (
+        "def format_analysis_provenance(",
+        "retrieved_at.astimezone(timezone.utc)",
+        'isoformat(timespec="seconds")',
+        '.replace("+00:00", "Z")',
+    ):
+        assert_true(contract in runtime, "runtime provenance helper must include {0}".format(contract))
+    for contract in (
+        "test_analysis_provenance_normalizes_station_range_and_utc_time",
+        "test_analysis_provenance_rejects_ambiguous_inputs",
+        'axes.set_title(weather_notebook.format_analysis_provenance(',
+        'axes.set_xlabel("Observation date")',
+        'axes.set_ylabel("Average temperature (degrees F)")',
+    ):
+        assert_true(contract in tests, "runtime provenance tests must include {0}".format(contract))
+    for contract in (
+        "from datetime import datetime, timezone",
+        "format_analysis_provenance",
+        "RETRIEVED_AT = datetime.now(timezone.utc)",
+        "axes.set_title(format_analysis_provenance(",
+        'axes.set_xlabel("Observation date")',
+        'axes.set_ylabel("Average temperature (degrees F)")',
+    ):
+        assert_true(contract in notebook, "notebook provenance flow must include {0}".format(contract))
+    assert_true(
+        notebook.index("record_observation(item, weather_by_date)") <
+        notebook.index("RETRIEVED_AT = datetime.now(timezone.utc)") <
+        notebook.index("rows = build_weather_rows(weather_by_date)"),
+        "retrieval completion time must be captured after NOAA collection and before plotting",
+    )
+    assert_true("repository's original sample selection" in readme,
+                "README must explain the station choice")
+    assert_true("keeps the analysis bounded and historical" in readme,
+                "README must explain the date-range choice")
+    assert_true("UTC retrieval completion time" in security, "SECURITY must preserve plot provenance")
+    assert_true("Include NOAA source, station, historical range" in vision,
+                "VISION must preserve generated plot provenance")
+    assert_true("deterministic provenance validation" in changes,
+                "CHANGES must record provenance validation")
+    assert_true("Document station and date-range choices" not in vision,
+                "completed station/date documentation must leave next priorities")
+    assert_true("Add data-source timestamps to generated outputs" not in vision,
+                "completed output timestamps must leave next priorities")
 
 
 def test_dependency_and_ci_contracts():
@@ -656,6 +714,7 @@ def main():
         test_notebook_skips_rows_without_measurements,
         test_completed_plans_are_in_docs_plans,
         test_synthetic_analysis_flow_is_exercised,
+        test_analysis_provenance_is_visible_and_deterministic,
         test_dependency_and_ci_contracts,
     ]
     for test in tests:

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -64,6 +64,9 @@ CONFLICTING_OBSERVATION_PLAN_PATH = (
 ANALYSIS_PROVENANCE_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-16-weather-analysis-provenance.md"
 )
+STABLE_RESULT_COUNT_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-16-stable-noaa-result-count.md"
+)
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "check.yml"
 LOCKFILE_SHA256 = {
     "requirements-py312.lock": "47835a6609db0175be86dd3054e5e2334668b35cf0d0d59e45208ef2fc716179",
@@ -231,7 +234,7 @@ def test_noaa_requests_are_paginated_with_a_safety_bound():
             "all_results.extend(results)",
             "next_offset += len(results)",
             "resultset = noaa_resultset(payload)",
-            "if len(all_results) == result_count:",
+            "if len(all_results) == expected_result_count:",
             "elif len(results) < NOAA_PAGE_LIMIT:",
             "return all_results",
             'raise ValueError("NOAA response exceeded the page safety limit")'):
@@ -276,6 +279,49 @@ def test_noaa_response_offsets_are_validated_before_accumulation():
         mismatch_guard < accumulation,
         "NOAA response offsets must be validated before page accumulation",
     )
+
+
+def test_noaa_result_counts_remain_stable_across_pages():
+    source = project_source()
+    tests = RUNTIME_TESTS.read_text()
+    for contract in (
+        "expected_result_count = None",
+        "if result_count is not None:",
+        "if expected_result_count is None:",
+        "expected_result_count = result_count",
+        "elif result_count != expected_result_count:",
+        'raise ValueError("NOAA result count changed during pagination")',
+        "if expected_result_count is not None:",
+        "if len(all_results) > expected_result_count:",
+        "if len(all_results) == expected_result_count:",
+    ):
+        assert_true(contract in source, "missing stable NOAA result-count contract {0}".format(contract))
+
+    assert_true(
+        source.index("elif result_count != expected_result_count:")
+        < source.index("all_results.extend(results)"),
+        "NOAA result-count drift must fail before page accumulation",
+    )
+    for test_name in (
+        "test_fetch_rejects_result_count_drift_between_pages",
+        "test_fetch_uses_pinned_count_when_later_metadata_is_omitted",
+    ):
+        assert_true(
+            "def {0}(self):".format(test_name) in tests,
+            "runtime coverage is missing {0}".format(test_name),
+        )
+
+    docs = {
+        "README.md": "NOAA result counts must remain stable across paginated responses",
+        "SECURITY.md": "NOAA result-count changes fail before later pages are accumulated",
+        "VISION.md": "Reject NOAA result-count drift across paginated responses",
+        "CHANGES.md": "Rejected NOAA result-count drift across paginated responses",
+    }
+    for relative_path, phrase in docs.items():
+        assert_true(
+            phrase in (ROOT / relative_path).read_text(),
+            "{0} must document stable NOAA result counts".format(relative_path),
+        )
 
 
 def test_noaa_result_shape_is_checked():
@@ -501,6 +547,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(SYNTHETIC_ANALYSIS_PLAN_PATH, "synthetic analysis flow")
     assert_completed_plan(CONFLICTING_OBSERVATION_PLAN_PATH, "conflicting NOAA observations")
     assert_completed_plan(ANALYSIS_PROVENANCE_PLAN_PATH, "weather analysis provenance")
+    assert_completed_plan(STABLE_RESULT_COUNT_PLAN_PATH, "stable NOAA result count")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_synthetic_analysis_flow_is_exercised," in checker_main,
@@ -509,6 +556,10 @@ def test_completed_plans_are_in_docs_plans():
     assert_true(
         "test_conflicting_observations_fail_before_mutation," in checker_main,
         "conflicting observation contract must run in the main suite",
+    )
+    assert_true(
+        "test_noaa_result_counts_remain_stable_across_pages," in checker_main,
+        "stable NOAA result-count contract must run in the main suite",
     )
 
 
@@ -704,6 +755,7 @@ def main():
         test_noaa_requests_are_paginated_with_a_safety_bound,
         test_noaa_pagination_metadata_is_validated,
         test_noaa_response_offsets_are_validated_before_accumulation,
+        test_noaa_result_counts_remain_stable_across_pages,
         test_noaa_result_shape_is_checked,
         test_notebook_has_no_stale_outputs,
         test_notebook_aligns_observations_by_date,

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -159,11 +159,19 @@ def test_noaa_requests_are_parameterized_and_bounded():
     assert_true("timeout=REQUEST_TIMEOUT_SECONDS" in source, "NOAA requests must set a timeout")
     assert_true("allow_redirects=False" in source, "NOAA token requests must not follow redirects")
     assert_true(".raise_for_status()" in source, "NOAA responses must fail fast on HTTP errors")
+    assert_true(
+        "response.status_code < 200 or response.status_code >= 300" in source,
+        "NOAA responses must explicitly reject redirects and other non-2xx statuses",
+    )
+    assert_true(
+        'raise ValueError("NOAA response must have a successful status")' in source,
+        "NOAA non-success status failures must be explicit",
+    )
     request_function = RUNTIME_MODULE.read_text().split("def fetch_noaa_data", 1)[1].split(
         "def noaa_resultset", 1
     )[0]
     assert_true(
-        request_function.index("response.raise_for_status()")
+        request_function.index("response.status_code < 200 or response.status_code >= 300")
         < request_function.index("payload = response.json()"),
         "NOAA redirects and HTTP failures must be rejected before JSON parsing",
     )
@@ -446,6 +454,10 @@ def test_notebook_guards_observation_dates_and_values():
     assert_true("if parsed_date is None:" in source, "row building must skip invalid NOAA dates")
     assert_true('"date": parsed_date' in source, "row building must use the guarded date value")
     assert_true("def noaa_number(value):" in source, "notebook must convert NOAA numeric values through a guard helper")
+    assert_true(
+        "isinstance(value, bool)" in source,
+        "NOAA numeric parsing must reject JSON booleans",
+    )
     assert_true("number = noaa_number(value)" in source, "unit conversion must use guarded numeric conversion")
     assert_true("import math" in source, "notebook must import math for finite numeric checks")
     assert_true(

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -69,8 +69,8 @@ STABLE_RESULT_COUNT_PLAN_PATH = (
 )
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "check.yml"
 LOCKFILE_SHA256 = {
-    "requirements-py312.lock": "47835a6609db0175be86dd3054e5e2334668b35cf0d0d59e45208ef2fc716179",
-    "requirements-py314.lock": "e82f04e40657676dfd0bb057f9158935acb594c053366e91d2f427a5db066b12",
+    "requirements-py312.lock": "552696e4d187043dac40208e56287c27994016e696b27adca9616ad463167e0a",
+    "requirements-py314.lock": "bd4805956fb10e570cc02bc32c4021caef6c553f12a167359fff7e72656165d1",
 }
 
 EXPECTED_WORKFLOW = """name: Check
@@ -708,6 +708,10 @@ def test_dependency_and_ci_contracts():
                 locked_packages.get(name) == version,
                 "{0} must contain active direct pin {1}=={2}".format(lock_name, name, version),
             )
+        assert_true(
+            locked_packages.get("jupyter-server") == "2.20.0",
+            "{0} must contain the reviewed jupyter-server security pin".format(lock_name),
+        )
 
     workflow = CI_WORKFLOW_PATH.read_text()
     assert_true(workflow == EXPECTED_WORKFLOW, "CI workflow must match the fail-closed baseline")

--- a/weather_notebook.py
+++ b/weather_notebook.py
@@ -1,5 +1,5 @@
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 
 import requests
 
@@ -9,6 +9,33 @@ REQUEST_TIMEOUT_SECONDS = 10
 NOAA_PAGE_LIMIT = 1000
 MAX_NOAA_PAGES = 20
 SUPPORTED_DATATYPES = {"TAVG", "TMIN", "TMAX", "PRCP"}
+
+
+def format_analysis_provenance(station_id, start_year, end_year_exclusive, retrieved_at):
+    if not isinstance(station_id, str) or not station_id.strip():
+        raise ValueError("station_id must be nonblank text")
+    if (
+            isinstance(start_year, bool) or not isinstance(start_year, int) or
+            isinstance(end_year_exclusive, bool) or not isinstance(end_year_exclusive, int) or
+            start_year < 1000 or end_year_exclusive > 9999 or
+            start_year >= end_year_exclusive):
+        raise ValueError("analysis years must define a valid four-digit range")
+    if not isinstance(retrieved_at, datetime):
+        raise ValueError("retrieved_at must be a datetime")
+    if retrieved_at.tzinfo is None or retrieved_at.utcoffset() is None:
+        raise ValueError("retrieved_at must include a timezone")
+
+    retrieved_utc = retrieved_at.astimezone(timezone.utc)
+    retrieved_text = retrieved_utc.isoformat(timespec="seconds").replace("+00:00", "Z")
+    return (
+        "NOAA CDO {0} | {1}-01-01 to {2}-12-31 | retrieved {3}"
+        .format(
+            station_id.strip(),
+            start_year,
+            end_year_exclusive - 1,
+            retrieved_text,
+        )
+    )
 
 
 def fetch_noaa_data(year, datatype_ids, token, station_id, requests_get=None):

--- a/weather_notebook.py
+++ b/weather_notebook.py
@@ -76,6 +76,8 @@ def fetch_noaa_data(year, datatype_ids, token, station_id, requests_get=None):
             allow_redirects=False,
         )
         response.raise_for_status()
+        if response.status_code < 200 or response.status_code >= 300:
+            raise ValueError("NOAA response must have a successful status")
         payload = response.json()
         if not isinstance(payload, dict):
             raise ValueError("NOAA response must be an object")
@@ -148,7 +150,7 @@ def parse_noaa_date(value):
 
 
 def noaa_number(value):
-    if value is None:
+    if value is None or isinstance(value, bool):
         return None
     try:
         number = float(value)

--- a/weather_notebook.py
+++ b/weather_notebook.py
@@ -56,6 +56,7 @@ def fetch_noaa_data(year, datatype_ids, token, station_id, requests_get=None):
     station_id = station_id.strip()
     all_results = []
     next_offset = 1
+    expected_result_count = None
     for _page_index in range(MAX_NOAA_PAGES):
         params = {
             "datasetid": "GHCND",
@@ -85,12 +86,17 @@ def fetch_noaa_data(year, datatype_ids, token, station_id, requests_get=None):
         result_count, response_offset = resultset or (None, None)
         if response_offset is not None and response_offset != next_offset:
             raise ValueError("NOAA response offset does not match request")
+        if result_count is not None:
+            if expected_result_count is None:
+                expected_result_count = result_count
+            elif result_count != expected_result_count:
+                raise ValueError("NOAA result count changed during pagination")
         all_results.extend(results)
         next_offset += len(results)
-        if result_count is not None:
-            if len(all_results) > result_count:
+        if expected_result_count is not None:
+            if len(all_results) > expected_result_count:
                 raise ValueError("NOAA result count is inconsistent")
-            if len(all_results) == result_count:
+            if len(all_results) == expected_result_count:
                 return all_results
             if not results:
                 raise ValueError("NOAA pagination made no progress")

--- a/weather_notebook_tests.py
+++ b/weather_notebook_tests.py
@@ -187,6 +187,49 @@ class WeatherNotebookTest(unittest.TestCase):
         self.assertEqual(results, [{"id": 1}, {"id": 2}, {"id": 3}])
         self.assertEqual(calls, [1, 3])
 
+    def test_fetch_rejects_result_count_drift_between_pages(self):
+        for later_count in (2, 4):
+            with self.subTest(later_count=later_count):
+                calls = []
+                pages = [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+
+                def fake_get(url, headers, params, timeout, allow_redirects):
+                    page_index = len(calls)
+                    calls.append(params["offset"])
+                    return FakeResponse({
+                        "results": pages[page_index],
+                        "metadata": {"resultset": {
+                            "count": 3 if page_index == 0 else later_count,
+                            "offset": calls[-1],
+                        }},
+                    })
+
+                with self.assertRaisesRegex(ValueError, "result count changed"):
+                    weather_notebook.fetch_noaa_data(
+                        2019, ["TAVG"], "token", "station", requests_get=fake_get
+                    )
+
+                self.assertEqual(calls, [1, 3])
+
+    def test_fetch_uses_pinned_count_when_later_metadata_is_omitted(self):
+        calls = []
+        pages = [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+
+        def fake_get(url, headers, params, timeout, allow_redirects):
+            page_index = len(calls)
+            calls.append(params["offset"])
+            payload = {"results": pages[page_index]}
+            if page_index == 0:
+                payload["metadata"] = {"resultset": {"count": 3, "offset": 1}}
+            return FakeResponse(payload)
+
+        results = weather_notebook.fetch_noaa_data(
+            2019, ["TAVG"], "token", "station", requests_get=fake_get
+        )
+
+        self.assertEqual(results, [{"id": 1}, {"id": 2}, {"id": 3}])
+        self.assertEqual(calls, [1, 3])
+
     def test_fetch_rejects_mismatched_response_offset_before_next_request(self):
         calls = []
 

--- a/weather_notebook_tests.py
+++ b/weather_notebook_tests.py
@@ -5,9 +5,10 @@ import weather_notebook
 
 
 class FakeResponse:
-    def __init__(self, payload, error=None):
+    def __init__(self, payload, error=None, status_code=200):
         self.payload = payload
         self.error = error
+        self.status_code = status_code
         self.json_calls = 0
 
     def raise_for_status(self):
@@ -318,14 +319,14 @@ class WeatherNotebookTest(unittest.TestCase):
     def test_fetch_rejects_redirect_before_parsing_json(self):
         response = FakeResponse(
             {"results": [{"must": "not be parsed"}]},
-            RuntimeError("redirect rejected"),
+            status_code=302,
         )
 
         def fake_get(url, headers, params, timeout, allow_redirects):
             self.assertFalse(allow_redirects)
             return response
 
-        with self.assertRaisesRegex(RuntimeError, "redirect rejected"):
+        with self.assertRaisesRegex(ValueError, "successful status"):
             weather_notebook.fetch_noaa_data(
                 2019, ["PRCP"], "token", "station", requests_get=fake_get
             )
@@ -453,6 +454,23 @@ class WeatherNotebookTest(unittest.TestCase):
         self.assertEqual(rows[0]["maxTemp"], 50.0)
         self.assertEqual(rows[1]["avgTemp"], 68.0)
         self.assertEqual(rows[1]["prcp"], 1.0)
+
+    def test_build_weather_rows_treats_boolean_measurements_as_missing(self):
+        rows = weather_notebook.build_weather_rows({
+            "2019-01-01T00:00:00": {"TAVG": True},
+            "2019-01-02T00:00:00": {"TAVG": 20},
+        })
+
+        self.assertEqual(
+            rows,
+            [{
+                "date": datetime(2019, 1, 2),
+                "avgTemp": 68.0,
+                "minTemp": None,
+                "maxTemp": None,
+                "prcp": None,
+            }],
+        )
 
     def test_build_weather_rows_rejects_empty_analysis(self):
         with self.assertRaisesRegex(ValueError, "No valid NOAA observations"):

--- a/weather_notebook_tests.py
+++ b/weather_notebook_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 import weather_notebook
 
@@ -20,6 +20,46 @@ class FakeResponse:
 
 
 class WeatherNotebookTest(unittest.TestCase):
+    def test_analysis_provenance_normalizes_station_range_and_utc_time(self):
+        retrieved_at = datetime(
+            2026, 6, 16, 5, 30, 45, 999999,
+            tzinfo=timezone(timedelta(hours=2)),
+        )
+
+        title = weather_notebook.format_analysis_provenance(
+            "  GHCND:US1CAMR0037  ", 2019, 2020, retrieved_at
+        )
+
+        self.assertEqual(
+            title,
+            "NOAA CDO GHCND:US1CAMR0037 | 2019-01-01 to 2019-12-31 | "
+            "retrieved 2026-06-16T03:30:45Z",
+        )
+
+    def test_analysis_provenance_rejects_ambiguous_inputs(self):
+        aware_time = datetime(2026, 6, 16, tzinfo=timezone.utc)
+        invalid_inputs = [
+            (None, 2019, 2020, aware_time),
+            ("   ", 2019, 2020, aware_time),
+            ("station", True, 2020, aware_time),
+            ("station", 999, 2020, aware_time),
+            ("station", 2020, 2020, aware_time),
+            ("station", 2019, 10000, aware_time),
+            ("station", 2019, 2020, "2026-06-16T00:00:00Z"),
+            ("station", 2019, 2020, datetime(2026, 6, 16)),
+        ]
+
+        for station_id, start_year, end_year, retrieved_at in invalid_inputs:
+            with self.subTest(
+                    station_id=station_id,
+                    start_year=start_year,
+                    end_year=end_year,
+                    retrieved_at=retrieved_at):
+                with self.assertRaises(ValueError):
+                    weather_notebook.format_analysis_provenance(
+                        station_id, start_year, end_year, retrieved_at
+                    )
+
     def test_fetch_rejects_invalid_inputs_before_request(self):
         calls = []
 
@@ -421,6 +461,14 @@ class WeatherNotebookTest(unittest.TestCase):
             columns=["date", "avgTemp", "minTemp", "maxTemp", "prcp"],
         )
         axes = dataframe.plot(kind="line", x="date", y="avgTemp")
+        axes.set_title(weather_notebook.format_analysis_provenance(
+            "synthetic-station",
+            2019,
+            2020,
+            datetime(2026, 6, 16, 3, 30, 45, tzinfo=timezone.utc),
+        ))
+        axes.set_xlabel("Observation date")
+        axes.set_ylabel("Average temperature (degrees F)")
 
         self.assertEqual(calls, [("TAVG", "TMAX"), ("TMIN", "PRCP")])
         self.assertEqual(list(dataframe.columns), [
@@ -432,7 +480,13 @@ class WeatherNotebookTest(unittest.TestCase):
         ])
         self.assertEqual(list(dataframe["avgTemp"]), [50.0, 68.0])
         self.assertEqual(len(axes.lines), 1)
-        self.assertEqual(axes.get_xlabel(), "date")
+        self.assertEqual(
+            axes.get_title(),
+            "NOAA CDO synthetic-station | 2019-01-01 to 2019-12-31 | "
+            "retrieved 2026-06-16T03:30:45Z",
+        )
+        self.assertEqual(axes.get_xlabel(), "Observation date")
+        self.assertEqual(axes.get_ylabel(), "Average temperature (degrees F)")
         plt.close(axes.figure)
 
 


### PR DESCRIPTION
## Summary

Weather analysis plots now retain the context needed to interpret or redistribute them safely: NOAA CDO source, normalized station, inclusive historical range, UTC retrieval completion time, and Fahrenheit units. The fixed station and 2019 range are documented as the repository’s original bounded sample, not current or representative climate data.

## Baseline

The notebook previously plotted average temperature with generic axes and no title. Screenshots or exported figures could lose their source, station, period, retrieval time, and unit context.

## Improvements

- Validate and format deterministic analysis provenance in the shared runtime module.
- Capture retrieval completion after all NOAA collection and apply the generated title before display.
- Label observation dates and average temperature units explicitly.
- Extend the synthetic offline flow and portable checker to cover UTC normalization, ambiguous input rejection, notebook ordering, title/labels, documentation, and roadmap completion.

## Validation

- Repository and external-directory `make check`: all 24 executable tests and 19 static contracts passed in each context.
- Nine isolated hostile mutations were rejected across source, station, range, UTC handling, timestamp, title, and axes labels.
- Notebook JSON is valid, all code-cell outputs and execution counts remain empty, and exact diff/artifact/mode/whitespace/conflict/credential audits passed.
- A fresh local hash-lock install could not complete because the internal package index did not expose `ipykernel==7.3.0`; lockfiles were unchanged and hosted matrix installation is required below.

## Risk

The notebook gains a runtime timestamp in its in-memory plot title, so repeated executions intentionally produce different retrieval metadata. No NOAA request, dependency, lockfile, workflow, station/date default, dataframe column, saved figure, or committed notebook output changed.

## Follow-Ups

- Treat the Python 3.12/3.14 hosted matrix as the authoritative exact-lock installation evidence.
- Preserve base-first ordering because this PR is stacked on PR #8.

## Post-Deploy Monitoring & Validation

- During the first reviewed notebook execution, the maintainer should confirm the title shows NOAA CDO, `GHCND:US1CAMR0037`, `2019-01-01 to 2019-12-31`, and a current UTC `Z` timestamp after retrieval completes.
- Healthy signal: successful plots retain the original dataframe values and line count while displaying the new provenance and units.
- Failure signal: a naive/non-UTC timestamp, missing context, changed station/range, or plot failure. Revert this commit if metadata is incorrect or blocks the existing analysis, then reproduce with the deterministic synthetic test before retrying.
- Validation window: first notebook execution after integration; owner: repository maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
