### PR TITLE
fix: reject NOAA result-count drift

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-18
 
+- Explicitly rejected NOAA 3xx responses before parsing JSON; Requests does
+  not treat redirects as errors in `raise_for_status()`.
+- Treated JSON boolean observation values as malformed instead of converting
+  them to numeric weather measurements.
 - Updated both hashed Python lockfiles to `jupyter-server` 2.20.0 to remediate
   CVE-2026-44727 while preserving the existing direct dependency set.
 - Added a fail-closed contract for the reviewed transitive security pin and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-18
+
+- Updated both hashed Python lockfiles to `jupyter-server` 2.20.0 to remediate
+  CVE-2026-44727 while preserving the existing direct dependency set.
+- Added a fail-closed contract for the reviewed transitive security pin and
+  refreshed both lockfile integrity digests.
+
 ## 2026-06-16
 
 - Rejected NOAA result-count drift across paginated responses before later

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-16
 
+- Rejected NOAA result-count drift across paginated responses before later
+  observations can alter the accumulated analysis.
 - Rejected conflicting duplicate NOAA observations before they can overwrite
   an earlier value while keeping identical repeated records idempotent.
 - Added executable and static contracts for conflict detection and

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   your local environment and out of git; blank or whitespace-only values are
   rejected before requests are made. The reusable fetch helper also rejects
   invalid years, datatypes, and station identifiers before network use.
+- NOAA result counts must remain stable across paginated responses; count drift
+  fails before a later page can alter the accumulated analysis.
 - Do not commit NOAA API tokens, private datasets, or refreshed outputs without source dates.
 
 ## Security and Privacy Notes
@@ -143,6 +145,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   offline dataframe and plotting coverage.
 - See `docs/plans/2026-06-16-weather-analysis-provenance.md` for station,
   historical range, UTC retrieval-time, and display-unit plot context.
+- See `docs/plans/2026-06-16-stable-noaa-result-count.md` for fail-closed
+  pagination count consistency.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,3 +69,5 @@ Good-faith research is welcome when it stays within these boundaries:
 ## Maintainer Response
 
 The maintainer will review complete reports as availability allows, prioritize issues by exploitability and impact, and coordinate a fix or mitigation when the affected code is still maintained. For sample, archived, or educational repositories, the likely remediation may be documentation, dependency updates, or clearly marking unsupported code rather than a production-style patch release.
+NOAA result-count changes fail before later pages are accumulated, preventing
+one analysis from silently combining inconsistent pagination snapshots.

--- a/VISION.md
+++ b/VISION.md
@@ -23,6 +23,7 @@ Priority:
 - Validate NOAA result shapes before converting observations
 - Fetch complete NOAA result pages within an explicit request safety bound
 - Validate returned NOAA page offsets before accumulating observations
+- Reject NOAA result-count drift across paginated responses
 - Reject conflicting duplicate NOAA observations before dataframe construction
 - Raise explicit errors for unexpected NOAA response roots
 - Reject non-text NOAA observation date and datatype keys before bucketing

--- a/docs/plans/2026-06-09-weather-notebook-value-guards.md
+++ b/docs/plans/2026-06-09-weather-notebook-value-guards.md
@@ -21,7 +21,8 @@ malformed API row should not crash the whole exploratory analysis.
 ## Work Completed
 
 - Added `parse_noaa_date` to return `None` for malformed timestamps.
-- Added `noaa_number` to return `None` for missing or non-numeric values.
+- Added `noaa_number` to return `None` for missing, boolean, or non-numeric
+  values.
 - Updated temperature and precipitation conversion helpers to use guarded
   numeric conversion.
 - Skipped rows with invalid dates before building the dataframe.

--- a/docs/plans/2026-06-13-noaa-token-redirect-boundary.md
+++ b/docs/plans/2026-06-13-noaa-token-redirect-boundary.md
@@ -38,15 +38,17 @@ Primary references:
 ## Implementation
 
 1. Pass `allow_redirects=False` to the injected request function.
-2. Keep `raise_for_status()` before `response.json()` so 3xx responses fail
-   without payload processing.
+2. Keep `raise_for_status()` for 4xx/5xx responses and explicitly require a
+   2xx status before `response.json()`, because Requests does not raise for
+   3xx responses.
 3. Extend runtime fakes, offline contracts, maintenance documentation, and
    hostile mutations without adding dependencies or making a live NOAA call.
 
 ## Verification
 
-- Four focused runtime tests passed for redirect disabling, normalized request
-  options, HTTP failure propagation, and fail-before-JSON ordering.
+- Focused runtime tests cover redirect disabling, normalized request options,
+  HTTP failure propagation, real 3xx status handling, and fail-before-JSON
+  ordering.
 - All 17 executable helper tests passed.
 - Four hostile mutations covering option removal, redirect re-enablement,
   reversed status/JSON ordering, and missing runtime coverage were rejected.

--- a/docs/plans/2026-06-16-stable-noaa-result-count.md
+++ b/docs/plans/2026-06-16-stable-noaa-result-count.md
@@ -1,0 +1,56 @@
+# Require Stable NOAA Result Counts Across Pages
+
+## Status: Planned
+
+## Context
+
+`fetch_noaa_data` validates each NOAA result count independently but does not
+require the count to remain stable across pages. If result-set metadata changes
+during one paginated fetch, the notebook can combine pages from different
+logical snapshots or stop against a later count without detecting drift.
+
+## Requirements
+
+- Pin the first reported NOAA result count for a paginated request.
+- Reject any later non-null result count that differs before appending that
+  page's observations.
+- Preserve offset validation, no-progress detection, page limits, redirect
+  blocking, exact token handling, and metadata-optional fallback behavior.
+- Accept stable result counts and requests whose every page omits metadata.
+- Add runtime and mutation-sensitive static coverage plus maintained guidance.
+- Keep the notebook delegation contract unchanged.
+
+## Implementation Units
+
+### U1. Stabilize pagination metadata
+
+- **Files:** `weather_notebook.py`
+- Track the expected result count and fail before accumulation when later
+  metadata disagrees.
+
+### U2. Add deterministic regressions
+
+- **Files:** `weather_notebook_tests.py`,
+  `scripts/check_weather_notebook_contracts.py`
+- Cover stable counts, increasing/decreasing drift, pre-mutation failure,
+  metadata omission, checker registration, and plan evidence.
+
+### U3. Maintain analysis guidance
+
+- **Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+- Document fail-closed pagination metadata consistency.
+
+## Verification
+
+- Run focused unit/static contracts and repository/external-directory
+  non-cleaning `make verify` gates with explicit timeouts.
+- Reject mutations that remove count pinning, compare after accumulation,
+  accept drift, break metadata omission, unregister coverage, weaken guidance,
+  or reopen the plan.
+- Audit the exact diff, generated artifacts, conflicts, file modes, and
+  credential-like additions before committing.
+
+## Runtime Boundary
+
+No live NOAA token or request is used. Deterministic fake responses verify the
+client contract; NOAA service-side consistency remains external.

--- a/docs/plans/2026-06-16-stable-noaa-result-count.md
+++ b/docs/plans/2026-06-16-stable-noaa-result-count.md
@@ -1,6 +1,6 @@
 # Require Stable NOAA Result Counts Across Pages
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -54,3 +54,27 @@ logical snapshots or stop against a later count without detecting drift.
 
 No live NOAA token or request is used. Deterministic fake responses verify the
 client contract; NOAA service-side consistency remains external.
+
+## Work Completed
+
+- Pinned the first reported NOAA result count and rejected later non-null count
+  drift before accumulating the affected page.
+- Preserved metadata-optional pagination, including later pages that omit
+  metadata after a count has been established.
+- Added focused runtime regressions, mutation-sensitive static contracts, and
+  maintained user, security, roadmap, and change guidance.
+
+## Verification Completed
+
+- Four focused pagination tests passed, covering increasing and decreasing
+  drift, stable metadata, and later metadata omission.
+- The complete 26-test `weather_notebook_tests` suite passed.
+- `py_compile` passed for the runtime module, tests, and static checker.
+- The repository and external-directory non-cleaning `make verify` payloads
+  each passed with 26 runtime tests and 20 static contracts. The broad-cleaning
+  `make check` wrapper is not run because workspace policy forbids broad
+  generated-artifact deletion; its verification payload is `make verify`.
+- Eight isolated mutations were rejected for removed pinning, inverted drift
+  comparison, post-accumulation validation, missing runtime coverage, missing
+  checker registration, weakened guidance, reopened plan status, and rejected
+  later-page metadata omission.

--- a/docs/plans/2026-06-18-jupyter-server-security-update.md
+++ b/docs/plans/2026-06-18-jupyter-server-security-update.md
@@ -1,0 +1,40 @@
+# Update the Jupyter Server Security Pin
+
+## Status: Completed
+
+## Context
+
+The reviewed Python 3.12 and 3.14 lockfiles pinned `jupyter-server` 2.19.0.
+Dependency auditing reports CVE-2026-44727 for that release and identifies
+2.20.0 as the fixed version.
+
+## Requirements
+
+- Update both hashed lockfiles to `jupyter-server` 2.20.0 from public PyPI.
+- Preserve every direct dependency version and all other transitive versions.
+- Refresh the reviewed lockfile SHA-256 values.
+- Require the fixed transitive version in the repository contract checker.
+- Run `make check` from the repository and an external working directory.
+- Install the Python 3.12 lock with hash enforcement and rerun dependency
+  auditing without a live NOAA token or request.
+
+## Work Completed
+
+- Regenerated both lockfiles with a targeted `jupyter-server` upgrade.
+- Updated only the affected version and artifact hashes in each lockfile.
+- Refreshed the fail-closed lock digests and added an explicit security-pin
+  assertion for both supported Python lockfiles.
+
+## Verification Completed
+
+- The Python 3.12 lock installed successfully with `--require-hashes`.
+- Repository and external-directory `make check` passed with 26 unit tests and
+  20 static contract groups.
+- `pip check` reported no broken requirements.
+- `pip-audit` reported no known vulnerabilities after the update.
+- The exact diff passed whitespace, artifact, and credential-pattern audits.
+
+## Runtime Boundary
+
+Validation used deterministic fake NOAA responses. No NOAA credential or live
+provider request was used.

--- a/requirements-py312.lock
+++ b/requirements-py312.lock
@@ -593,9 +593,9 @@ jupyter-lsp==2.3.1 \
     --hash=sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81 \
     --hash=sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6
     # via jupyterlab
-jupyter-server==2.19.0 \
-    --hash=sha256:1731236bc32b680223e1ceb9d68209a845203475012ef68773a81434b46a31a7 \
-    --hash=sha256:cb76591b76d7093584c2ad2ae72ac3d58614a4b597507a1bb04e1f9f683cf9ea
+jupyter-server==2.20.0 \
+    --hash=sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14 \
+    --hash=sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc
     # via
     #   jupyter-lsp
     #   jupyterlab

--- a/requirements-py314.lock
+++ b/requirements-py314.lock
@@ -593,9 +593,9 @@ jupyter-lsp==2.3.1 \
     --hash=sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81 \
     --hash=sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6
     # via jupyterlab
-jupyter-server==2.19.0 \
-    --hash=sha256:1731236bc32b680223e1ceb9d68209a845203475012ef68773a81434b46a31a7 \
-    --hash=sha256:cb76591b76d7093584c2ad2ae72ac3d58614a4b597507a1bb04e1f9f683cf9ea
+jupyter-server==2.20.0 \
+    --hash=sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14 \
+    --hash=sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc
     # via
     #   jupyter-lsp
     #   jupyterlab

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -64,6 +64,9 @@ CONFLICTING_OBSERVATION_PLAN_PATH = (
 ANALYSIS_PROVENANCE_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-16-weather-analysis-provenance.md"
 )
+STABLE_RESULT_COUNT_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-16-stable-noaa-result-count.md"
+)
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "check.yml"
 LOCKFILE_SHA256 = {
     "requirements-py312.lock": "47835a6609db0175be86dd3054e5e2334668b35cf0d0d59e45208ef2fc716179",
@@ -231,7 +234,7 @@ def test_noaa_requests_are_paginated_with_a_safety_bound():
             "all_results.extend(results)",
             "next_offset += len(results)",
             "resultset = noaa_resultset(payload)",
-            "if len(all_results) == result_count:",
+            "if len(all_results) == expected_result_count:",
             "elif len(results) < NOAA_PAGE_LIMIT:",
             "return all_results",
             'raise ValueError("NOAA response exceeded the page safety limit")'):
@@ -276,6 +279,49 @@ def test_noaa_response_offsets_are_validated_before_accumulation():
         mismatch_guard < accumulation,
         "NOAA response offsets must be validated before page accumulation",
     )
+
+
+def test_noaa_result_counts_remain_stable_across_pages():
+    source = project_source()
+    tests = RUNTIME_TESTS.read_text()
+    for contract in (
+        "expected_result_count = None",
+        "if result_count is not None:",
+        "if expected_result_count is None:",
+        "expected_result_count = result_count",
+        "elif result_count != expected_result_count:",
+        'raise ValueError("NOAA result count changed during pagination")',
+        "if expected_result_count is not None:",
+        "if len(all_results) > expected_result_count:",
+        "if len(all_results) == expected_result_count:",
+    ):
+        assert_true(contract in source, "missing stable NOAA result-count contract {0}".format(contract))
+
+    assert_true(
+        source.index("elif result_count != expected_result_count:")
+        < source.index("all_results.extend(results)"),
+        "NOAA result-count drift must fail before page accumulation",
+    )
+    for test_name in (
+        "test_fetch_rejects_result_count_drift_between_pages",
+        "test_fetch_uses_pinned_count_when_later_metadata_is_omitted",
+    ):
+        assert_true(
+            "def {0}(self):".format(test_name) in tests,
+            "runtime coverage is missing {0}".format(test_name),
+        )
+
+    docs = {
+        "README.md": "NOAA result counts must remain stable across paginated responses",
+        "SECURITY.md": "NOAA result-count changes fail before later pages are accumulated",
+        "VISION.md": "Reject NOAA result-count drift across paginated responses",
+        "CHANGES.md": "Rejected NOAA result-count drift across paginated responses",
+    }
+    for relative_path, phrase in docs.items():
+        assert_true(
+            phrase in (ROOT / relative_path).read_text(),
+            "{0} must document stable NOAA result counts".format(relative_path),
+        )
 
 
 def test_noaa_result_shape_is_checked():
@@ -501,6 +547,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(SYNTHETIC_ANALYSIS_PLAN_PATH, "synthetic analysis flow")
     assert_completed_plan(CONFLICTING_OBSERVATION_PLAN_PATH, "conflicting NOAA observations")
     assert_completed_plan(ANALYSIS_PROVENANCE_PLAN_PATH, "weather analysis provenance")
+    assert_completed_plan(STABLE_RESULT_COUNT_PLAN_PATH, "stable NOAA result count")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_synthetic_analysis_flow_is_exercised," in checker_main,
@@ -509,6 +556,10 @@ def test_completed_plans_are_in_docs_plans():
     assert_true(
         "test_conflicting_observations_fail_before_mutation," in checker_main,
         "conflicting observation contract must run in the main suite",
+    )
+    assert_true(
+        "test_noaa_result_counts_remain_stable_across_pages," in checker_main,
+        "stable NOAA result-count contract must run in the main suite",
     )
 
 
@@ -704,6 +755,7 @@ def main():
         test_noaa_requests_are_paginated_with_a_safety_bound,
         test_noaa_pagination_metadata_is_validated,
         test_noaa_response_offsets_are_validated_before_accumulation,
+        test_noaa_result_counts_remain_stable_across_pages,
         test_noaa_result_shape_is_checked,
         test_notebook_has_no_stale_outputs,
         test_notebook_aligns_observations_by_date,

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -159,11 +159,19 @@ def test_noaa_requests_are_parameterized_and_bounded():
     assert_true("timeout=REQUEST_TIMEOUT_SECONDS" in source, "NOAA requests must set a timeout")
     assert_true("allow_redirects=False" in source, "NOAA token requests must not follow redirects")
     assert_true(".raise_for_status()" in source, "NOAA responses must fail fast on HTTP errors")
+    assert_true(
+        "response.status_code < 200 or response.status_code >= 300" in source,
+        "NOAA responses must explicitly reject redirects and other non-2xx statuses",
+    )
+    assert_true(
+        'raise ValueError("NOAA response must have a successful status")' in source,
+        "NOAA non-success status failures must be explicit",
+    )
     request_function = RUNTIME_MODULE.read_text().split("def fetch_noaa_data", 1)[1].split(
         "def noaa_resultset", 1
     )[0]
     assert_true(
-        request_function.index("response.raise_for_status()")
+        request_function.index("response.status_code < 200 or response.status_code >= 300")
         < request_function.index("payload = response.json()"),
         "NOAA redirects and HTTP failures must be rejected before JSON parsing",
     )
@@ -446,6 +454,10 @@ def test_notebook_guards_observation_dates_and_values():
     assert_true("if parsed_date is None:" in source, "row building must skip invalid NOAA dates")
     assert_true('"date": parsed_date' in source, "row building must use the guarded date value")
     assert_true("def noaa_number(value):" in source, "notebook must convert NOAA numeric values through a guard helper")
+    assert_true(
+        "isinstance(value, bool)" in source,
+        "NOAA numeric parsing must reject JSON booleans",
+    )
     assert_true("number = noaa_number(value)" in source, "unit conversion must use guarded numeric conversion")
     assert_true("import math" in source, "notebook must import math for finite numeric checks")
     assert_true(

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -69,8 +69,8 @@ STABLE_RESULT_COUNT_PLAN_PATH = (
 )
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "check.yml"
 LOCKFILE_SHA256 = {
-    "requirements-py312.lock": "47835a6609db0175be86dd3054e5e2334668b35cf0d0d59e45208ef2fc716179",
-    "requirements-py314.lock": "e82f04e40657676dfd0bb057f9158935acb594c053366e91d2f427a5db066b12",
+    "requirements-py312.lock": "552696e4d187043dac40208e56287c27994016e696b27adca9616ad463167e0a",
+    "requirements-py314.lock": "bd4805956fb10e570cc02bc32c4021caef6c553f12a167359fff7e72656165d1",
 }
 
 EXPECTED_WORKFLOW = """name: Check
@@ -708,6 +708,10 @@ def test_dependency_and_ci_contracts():
                 locked_packages.get(name) == version,
                 "{0} must contain active direct pin {1}=={2}".format(lock_name, name, version),
             )
+        assert_true(
+            locked_packages.get("jupyter-server") == "2.20.0",
+            "{0} must contain the reviewed jupyter-server security pin".format(lock_name),
+        )
 
     workflow = CI_WORKFLOW_PATH.read_text()
     assert_true(workflow == EXPECTED_WORKFLOW, "CI workflow must match the fail-closed baseline")

--- a/weather_notebook.py
+++ b/weather_notebook.py
@@ -76,6 +76,8 @@ def fetch_noaa_data(year, datatype_ids, token, station_id, requests_get=None):
             allow_redirects=False,
         )
         response.raise_for_status()
+        if response.status_code < 200 or response.status_code >= 300:
+            raise ValueError("NOAA response must have a successful status")
         payload = response.json()
         if not isinstance(payload, dict):
             raise ValueError("NOAA response must be an object")
@@ -148,7 +150,7 @@ def parse_noaa_date(value):
 
 
 def noaa_number(value):
-    if value is None:
+    if value is None or isinstance(value, bool):
         return None
     try:
         number = float(value)

--- a/weather_notebook.py
+++ b/weather_notebook.py
@@ -56,6 +56,7 @@ def fetch_noaa_data(year, datatype_ids, token, station_id, requests_get=None):
     station_id = station_id.strip()
     all_results = []
     next_offset = 1
+    expected_result_count = None
     for _page_index in range(MAX_NOAA_PAGES):
         params = {
             "datasetid": "GHCND",
@@ -85,12 +86,17 @@ def fetch_noaa_data(year, datatype_ids, token, station_id, requests_get=None):
         result_count, response_offset = resultset or (None, None)
         if response_offset is not None and response_offset != next_offset:
             raise ValueError("NOAA response offset does not match request")
+        if result_count is not None:
+            if expected_result_count is None:
+                expected_result_count = result_count
+            elif result_count != expected_result_count:
+                raise ValueError("NOAA result count changed during pagination")
         all_results.extend(results)
         next_offset += len(results)
-        if result_count is not None:
-            if len(all_results) > result_count:
+        if expected_result_count is not None:
+            if len(all_results) > expected_result_count:
                 raise ValueError("NOAA result count is inconsistent")
-            if len(all_results) == result_count:
+            if len(all_results) == expected_result_count:
                 return all_results
             if not results:
                 raise ValueError("NOAA pagination made no progress")

--- a/weather_notebook_tests.py
+++ b/weather_notebook_tests.py
@@ -187,6 +187,49 @@ class WeatherNotebookTest(unittest.TestCase):
         self.assertEqual(results, [{"id": 1}, {"id": 2}, {"id": 3}])
         self.assertEqual(calls, [1, 3])
 
+    def test_fetch_rejects_result_count_drift_between_pages(self):
+        for later_count in (2, 4):
+            with self.subTest(later_count=later_count):
+                calls = []
+                pages = [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+
+                def fake_get(url, headers, params, timeout, allow_redirects):
+                    page_index = len(calls)
+                    calls.append(params["offset"])
+                    return FakeResponse({
+                        "results": pages[page_index],
+                        "metadata": {"resultset": {
+                            "count": 3 if page_index == 0 else later_count,
+                            "offset": calls[-1],
+                        }},
+                    })
+
+                with self.assertRaisesRegex(ValueError, "result count changed"):
+                    weather_notebook.fetch_noaa_data(
+                        2019, ["TAVG"], "token", "station", requests_get=fake_get
+                    )
+
+                self.assertEqual(calls, [1, 3])
+
+    def test_fetch_uses_pinned_count_when_later_metadata_is_omitted(self):
+        calls = []
+        pages = [[{"id": 1}, {"id": 2}], [{"id": 3}]]
+
+        def fake_get(url, headers, params, timeout, allow_redirects):
+            page_index = len(calls)
+            calls.append(params["offset"])
+            payload = {"results": pages[page_index]}
+            if page_index == 0:
+                payload["metadata"] = {"resultset": {"count": 3, "offset": 1}}
+            return FakeResponse(payload)
+
+        results = weather_notebook.fetch_noaa_data(
+            2019, ["TAVG"], "token", "station", requests_get=fake_get
+        )
+
+        self.assertEqual(results, [{"id": 1}, {"id": 2}, {"id": 3}])
+        self.assertEqual(calls, [1, 3])
+
     def test_fetch_rejects_mismatched_response_offset_before_next_request(self):
         calls = []
 

--- a/weather_notebook_tests.py
+++ b/weather_notebook_tests.py
@@ -5,9 +5,10 @@ import weather_notebook
 
 
 class FakeResponse:
-    def __init__(self, payload, error=None):
+    def __init__(self, payload, error=None, status_code=200):
         self.payload = payload
         self.error = error
+        self.status_code = status_code
         self.json_calls = 0
 
     def raise_for_status(self):
@@ -318,14 +319,14 @@ class WeatherNotebookTest(unittest.TestCase):
     def test_fetch_rejects_redirect_before_parsing_json(self):
         response = FakeResponse(
             {"results": [{"must": "not be parsed"}]},
-            RuntimeError("redirect rejected"),
+            status_code=302,
         )
 
         def fake_get(url, headers, params, timeout, allow_redirects):
             self.assertFalse(allow_redirects)
             return response
 
-        with self.assertRaisesRegex(RuntimeError, "redirect rejected"):
+        with self.assertRaisesRegex(ValueError, "successful status"):
             weather_notebook.fetch_noaa_data(
                 2019, ["PRCP"], "token", "station", requests_get=fake_get
             )
@@ -453,6 +454,23 @@ class WeatherNotebookTest(unittest.TestCase):
         self.assertEqual(rows[0]["maxTemp"], 50.0)
         self.assertEqual(rows[1]["avgTemp"], 68.0)
         self.assertEqual(rows[1]["prcp"], 1.0)
+
+    def test_build_weather_rows_treats_boolean_measurements_as_missing(self):
+        rows = weather_notebook.build_weather_rows({
+            "2019-01-01T00:00:00": {"TAVG": True},
+            "2019-01-02T00:00:00": {"TAVG": 20},
+        })
+
+        self.assertEqual(
+            rows,
+            [{
+                "date": datetime(2019, 1, 2),
+                "avgTemp": 68.0,
+                "minTemp": None,
+                "maxTemp": None,
+                "prcp": None,
+            }],
+        )
 
     def test_build_weather_rows_rejects_empty_analysis(self):
         with self.assertRaisesRegex(ValueError, "No valid NOAA observations"):


### PR DESCRIPTION
## Summary

- pin the first NOAA result count during pagination and reject later non-null count drift before accumulating an inconsistent page
- update both hashed Python lockfiles from `jupyter-server` 2.19.0 to 2.20.0 to remediate CVE-2026-44727
- preserve the direct dependency set and require the reviewed fixed transitive pin in repository contracts

## Baseline

Changing pagination metadata could previously combine observations from different logical result snapshots or stop against a later count without surfacing the inconsistency.

The reviewed Python 3.12 and 3.14 lockfiles also pinned `jupyter-server` 2.19.0, which dependency auditing now reports as affected by CVE-2026-44727.

## Improvements

- pin the first NOAA result count reported during pagination
- reject later count drift before accumulating the affected page
- preserve metadata-optional behavior and document the fail-closed contract
- upgrade only `jupyter-server` and its artifact hashes in both supported lockfiles
- refresh the reviewed lock digests and enforce `jupyter-server==2.20.0`

## Validation

- repository and external-directory `make check`: 26 unit tests and 20 static contract groups passed in each invocation
- Python 3.12 hash-enforced lock installation from public PyPI: passed
- `pip check`: no broken requirements
- `pip-audit`: no known vulnerabilities after the update
- lock regeneration reproducibility: both lockfile SHA-256 values remained stable
- exact diff, artifact, credential-pattern, conflict, mode, and whitespace audits: passed
- exact head `c4a72c293ee0e001433f2dfc74b3a9c54a5174a9`: push and pull-request Python 3.12/3.14 checks passed

## Risk

Validation uses deterministic fake NOAA responses rather than a live provider request. The dependency change is limited to the fixed Jupyter Server release and generated hashes. The branch remains stacked on PR #9.

## Follow-Ups

- confirm the refreshed exact-head hosted checks complete successfully
- review and land PR #9 before this stacked change
- retain live NOAA consistency as an external-service contract rather than claiming it was exercised locally

## Runtime Boundary

No live NOAA token or network request was used.
