### PR TITLE
fix: update vulnerable JupyterLab lock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-20
+
+- Updated both hashed Python lockfiles to `jupyterlab` 4.5.9 to remediate
+  GHSA-vmhf-c436-hxj4 while preserving the existing direct dependency set.
+- Added a fail-closed contract for the reviewed transitive security pin and
+  refreshed both lockfile integrity digests.
+
 ## 2026-06-18
 
 - Explicitly rejected NOAA 3xx responses before parsing JSON; Requests does

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,6 +56,11 @@ that a historical sample is redistributed as current or representative data.
 
 Dependency updates should come from trusted package managers and should keep lockfiles in sync when lockfiles exist. Do not commit credentials, private keys, tokens, generated secrets, or machine-local configuration. If a vulnerability depends on a compromised package, typosquatting risk, insecure transitive dependency, or unsafe build step, include the package name, affected version, and the path through which it is used.
 
+The reviewed Python 3.12 and 3.14 lockfiles require JupyterLab 4.5.9 or later
+within the current 4.5 release line. Earlier releases are affected by
+GHSA-vmhf-c436-hxj4, a stored cross-site scripting issue in extension package
+metadata handling.
+
 ## Safe Research Guidelines
 
 Good-faith research is welcome when it stays within these boundaries:

--- a/docs/plans/2026-06-20-jupyterlab-security-update.md
+++ b/docs/plans/2026-06-20-jupyterlab-security-update.md
@@ -1,0 +1,43 @@
+# Update the JupyterLab Security Pin
+
+## Status: Completed
+
+## Context
+
+The reviewed Python 3.12 and 3.14 lockfiles pinned JupyterLab 4.5.8. GitHub
+Advisory GHSA-vmhf-c436-hxj4 identifies that release as affected by stored
+cross-site scripting through unsanitized extension package metadata and lists
+4.5.9 as the first patched version.
+
+## Requirements
+
+- Update both hashed lockfiles to JupyterLab 4.5.9 from public PyPI.
+- Preserve every direct dependency version and all unrelated transitive
+  versions.
+- Refresh the reviewed lockfile SHA-256 values.
+- Require the patched transitive version in the repository contract checker.
+- Run `make check` from the repository and an external working directory.
+- Install the Python 3.12 lock with hash enforcement and rerun dependency
+  auditing without a live NOAA token or request.
+
+## Work Completed
+
+- Regenerated both lockfiles with a targeted JupyterLab upgrade.
+- Updated only JupyterLab and its artifact hashes in each lockfile.
+- Refreshed the fail-closed lock digests and added an explicit security-pin
+  assertion for both supported Python lockfiles.
+
+## Verification Completed
+
+- The Python 3.12 lock installed successfully with hash enforcement from
+  public PyPI.
+- Repository, external-directory, and hostile-root `make check` passed with 27
+  unit tests and 20 static contract groups.
+- `pip check` reported no broken requirements.
+- `pip-audit` reported no known vulnerabilities after the update.
+- The exact diff passed whitespace, artifact, and credential-pattern audits.
+
+## Runtime Boundary
+
+Validation used deterministic fake NOAA responses. No NOAA credential or live
+provider request was used.

--- a/requirements-py312.lock
+++ b/requirements-py312.lock
@@ -606,9 +606,9 @@ jupyter-server-terminals==0.5.4 \
     --hash=sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14 \
     --hash=sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5
     # via jupyter-server
-jupyterlab==4.5.8 \
-    --hash=sha256:7d514c856d0d607601ec7692374da4f26e2aaf3b6e7cd363136b422a50588d6c \
-    --hash=sha256:af54d7242cc689a1e6c3ad213cc9b6d9781787d9ec67c52ec9a8f4707088cadd
+jupyterlab==4.5.9 \
+    --hash=sha256:5ff0f908e8ac0afbed32b106fdef360f101c0a6654d1bf4a81e98a293ae1b336 \
+    --hash=sha256:dd79a073fecae7a39066ea99e4627ed6c76269ac926e95a810e1e1df6358d865
     # via
     #   jupyter
     #   notebook

--- a/requirements-py314.lock
+++ b/requirements-py314.lock
@@ -606,9 +606,9 @@ jupyter-server-terminals==0.5.4 \
     --hash=sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14 \
     --hash=sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5
     # via jupyter-server
-jupyterlab==4.5.8 \
-    --hash=sha256:7d514c856d0d607601ec7692374da4f26e2aaf3b6e7cd363136b422a50588d6c \
-    --hash=sha256:af54d7242cc689a1e6c3ad213cc9b6d9781787d9ec67c52ec9a8f4707088cadd
+jupyterlab==4.5.9 \
+    --hash=sha256:5ff0f908e8ac0afbed32b106fdef360f101c0a6654d1bf4a81e98a293ae1b336 \
+    --hash=sha256:dd79a073fecae7a39066ea99e4627ed6c76269ac926e95a810e1e1df6358d865
     # via
     #   jupyter
     #   notebook

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -67,10 +67,13 @@ ANALYSIS_PROVENANCE_PLAN_PATH = (
 STABLE_RESULT_COUNT_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-16-stable-noaa-result-count.md"
 )
+JUPYTERLAB_SECURITY_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-20-jupyterlab-security-update.md"
+)
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "check.yml"
 LOCKFILE_SHA256 = {
-    "requirements-py312.lock": "552696e4d187043dac40208e56287c27994016e696b27adca9616ad463167e0a",
-    "requirements-py314.lock": "bd4805956fb10e570cc02bc32c4021caef6c553f12a167359fff7e72656165d1",
+    "requirements-py312.lock": "b59381ed41e79c40080b1ec5f772559bcc26bf33fa746e3d242304c24142fa4c",
+    "requirements-py314.lock": "f4346cb498a51f19ea5123454dc06942fb68d80bd0a837ac2f16d37d34988876",
 }
 
 EXPECTED_WORKFLOW = """name: Check
@@ -560,6 +563,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(CONFLICTING_OBSERVATION_PLAN_PATH, "conflicting NOAA observations")
     assert_completed_plan(ANALYSIS_PROVENANCE_PLAN_PATH, "weather analysis provenance")
     assert_completed_plan(STABLE_RESULT_COUNT_PLAN_PATH, "stable NOAA result count")
+    assert_completed_plan(JUPYTERLAB_SECURITY_PLAN_PATH, "JupyterLab security update")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_synthetic_analysis_flow_is_exercised," in checker_main,
@@ -723,6 +727,10 @@ def test_dependency_and_ci_contracts():
         assert_true(
             locked_packages.get("jupyter-server") == "2.20.0",
             "{0} must contain the reviewed jupyter-server security pin".format(lock_name),
+        )
+        assert_true(
+            locked_packages.get("jupyterlab") == "4.5.9",
+            "{0} must contain the reviewed jupyterlab security pin".format(lock_name),
         )
 
     workflow = CI_WORKFLOW_PATH.read_text()


### PR DESCRIPTION
## Summary

Historical pull request metadata normalized for engineering-bar traceability. The original description is preserved verbatim below.

## Baseline

This pull request predates the current standardized engineering-bar description format.

## Improvements

- Preserves the original code, commits, review state, and pull request state.
- Adds structured documentation headings only; no repository files or merge decisions change.

## Validation

- Confirmed pull request #11 remains merged at head `d099ad6816854e6cd4b1f3ac9ec6d54f7b4adc68`.
- Confirmed this edit changes only the pull request description.

## Risk

No runtime or repository risk; this is metadata-only normalization.

## Follow-Ups

None required for this historical pull request.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because no repository or deployed runtime content changed.

## Original PR Description

## Summary

Update both supported hash-locked dependency graphs from JupyterLab 4.5.8 to 4.5.9, remediating GHSA-vmhf-c436-hxj4.

## Why

JupyterLab 4.5.8 is affected by stored cross-site scripting through an unsanitized URI protocol in extension package metadata. GitHub identifies 4.5.9 as the first patched version. JupyterLab is transitive through the existing `jupyter==1.1.1` direct pin.

## Changes

- update only JupyterLab and its artifact hashes in the Python 3.12 and 3.14 lockfiles
- refresh the reviewed lockfile SHA-256 values
- require JupyterLab 4.5.9 in the fail-closed dependency contract
- document the advisory, supply-chain boundary, and completed validation plan

## Validation

- hash-enforced Python 3.12 lock installation from public PyPI: passed
- `pip check`: all 106 installed packages compatible
- root `make lint`, `make test`, `make build`, `make verify`, and `make check`: passed
- external-directory and hostile `ROOT=/nonexistent` `make check`: passed
- each complete gate: 27 unit tests and 20 static contract groups
- hostile downgrade with a refreshed lock digest: rejected by the JupyterLab security pin
- `pip-audit --require-hashes`: no known vulnerabilities
- `git diff --check`, `git fsck --strict`, artifact and credential screens: passed

## Risk

The update changes one transitive notebook UI package within the current 4.5 release line. Deterministic offline NOAA tests passed, but no live NOAA request or interactive JupyterLab browser session was exercised.

## Rollback

Revert `d099ad6`. That restores vulnerable JupyterLab 4.5.8, so rollback should occur only with another validated release that is not affected by GHSA-vmhf-c436-hxj4.

