### PR TITLE
ci: isolate weather notebook Make authority

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Verify scientific stack imports
         run: python -c "import jupyter, matplotlib, numpy, pandas, requests"
       - name: Run repository checks
-        run: make check
+        run: /usr/bin/make check
       - name: Verify external working directory
-        run: cd "$(mktemp -d)" && make -f "$GITHUB_WORKSPACE/Makefile" check
+        run: cd "$(mktemp -d)" && /usr/bin/make -f "$GITHUB_WORKSPACE/Makefile" check

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2026-06-21
+
+- Isolated Make verification authority from caller-controlled roots, shells,
+  startup files, Makefile lists, unsafe modes, executable Make syntax, and
+  later single-colon public recipe replacement.
+- Added literal Python/uv, lock-command, cleanup-containment, and external-root
+  authority coverage and invoked hosted verification through `/usr/bin/make`.
+
 ## 2026-06-20
 
 - Updated both hashed Python lockfiles to `jupyterlab` 4.5.9 to remediate

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,100 @@
+.DEFAULT_GOAL := check
+.PHONY: __repository-make-authority build check clean lint lock root-test test verify
+.SECONDEXPANSION:
+
 PYTHON ?= python3
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-CONTRACT_SCRIPT := $(ROOT)/scripts/check_weather_notebook_contracts.py
-PYTHON_FILES := $(ROOT)/weather_notebook.py $(ROOT)/weather_notebook_tests.py $(CONTRACT_SCRIPT)
+override PYTHON := $(value PYTHON)
+export PYTHON
+UV ?= uv
+override UV := $(value UV)
+export UV
+override REPOSITORY_MAKE_DOLLAR := $$
+override REPOSITORY_MAKE_OPEN := (
+ifneq ($(findstring $(REPOSITORY_MAKE_DOLLAR)$(REPOSITORY_MAKE_OPEN),$(value PYTHON)),)
+$(error PYTHON must be a literal executable path, not Make syntax)
+endif
+ifneq ($(findstring $(REPOSITORY_MAKE_DOLLAR)$(REPOSITORY_MAKE_OPEN),$(value UV)),)
+$(error UV must be a literal executable path, not Make syntax)
+endif
+override SHELL := /bin/sh
+override .SHELLFLAGS := -c
+build check clean lint lock root-test test verify __repository-make-authority: override SHELL := /bin/sh
+build check clean lint lock root-test test verify __repository-make-authority: override .SHELLFLAGS := -c
 
-.PHONY: clean lint lock test build verify check
+ifneq ($(filter command line,$(origin MAKEFLAGS)),)
+$(error MAKEFLAGS must not be overridden for repository verification)
+endif
+override REPOSITORY_MAKE_FIRST_FLAGS := $(firstword $(MAKEFLAGS))
+ifneq ($(filter -%,$(REPOSITORY_MAKE_FIRST_FLAGS)),)
+override REPOSITORY_MAKE_FIRST_FLAGS :=
+endif
+override REPOSITORY_MAKE_SHORT_FLAGS := $(REPOSITORY_MAKE_FIRST_FLAGS) $(filter-out --%,$(filter -%,$(MAKEFLAGS)))
+ifneq ($(findstring n,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring t,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring q,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(findstring i,$(REPOSITORY_MAKE_SHORT_FLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(filter --just-print --dry-run --recon --touch --question --ignore-errors,$(MAKEFLAGS)),)
+$(error non-executing or error-ignoring MAKEFLAGS are not supported for repository verification)
+endif
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(value MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+export ROOT
+ifeq ($(strip $(ROOT)),)
+$(error repository Makefile path could not be resolved)
+endif
+override REPOSITORY_SHELL_LITERAL = $(subst $$,$$$$,$(subst ','"'"',$1))
+override REPOSITORY_ROOT_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(ROOT))
+override REPOSITORY_PYTHON_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(PYTHON))
+override REPOSITORY_UV_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(UV))
 
-clean:
-	find "$(ROOT)" -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
-	find "$(ROOT)" -type d -name '__pycache__' -prune -exec rm -rf {} +
+build check clean lint lock root-test test verify:: $$(if $$(filter file,$$(origin MAKEFILE_LIST)),,$$(error MAKEFILE_LIST must not be overridden))
+build check clean lint lock root-test test verify:: $$(if $$(shell path=$$$$(/usr/bin/printf '%s' '$$(subst ','"'"',$$(MAKEFILE_LIST))' | /usr/bin/sed 's/^ //') && [ -f "$$$$path" ] && /usr/bin/printf '%s' ok),,$$(error repository Makefile must be loaded alone))
+build check clean lint lock root-test test verify:: __repository-make-authority
 
-lint:
-	cd "$(ROOT)" && PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m py_compile $(PYTHON_FILES)
+__repository-make-authority::
+	@:
 
-lock:
-	cd "$(ROOT)" && uv pip compile requirements.txt --python-version 3.12 --python-platform x86_64-manylinux_2_28 --default-index https://pypi.org/simple --generate-hashes --custom-compile-command 'make lock' --output-file requirements-py312.lock
-	cd "$(ROOT)" && uv pip compile requirements.txt --python-version 3.14 --python-platform x86_64-manylinux_2_28 --default-index https://pypi.org/simple --generate-hashes --custom-compile-command 'make lock' --output-file requirements-py314.lock
+define REPOSITORY_PUBLIC_RECIPES
+clean::
+	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
+	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type d -name '__pycache__' -prune -exec /bin/rm -rf {} +
 
-test:
-	cd "$(ROOT)" && PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -m unittest weather_notebook_tests
-	cd "$(ROOT)" && PYTHONDONTWRITEBYTECODE=1 $(PYTHON) $(CONTRACT_SCRIPT)
+lint::
+	PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' -m py_compile '$(REPOSITORY_ROOT_LITERAL)/weather_notebook.py' '$(REPOSITORY_ROOT_LITERAL)/weather_notebook_tests.py' '$(REPOSITORY_ROOT_LITERAL)/scripts/check_weather_notebook_contracts.py'
 
-build:
-	@echo "Notebook project: no build artifact to compile."
+lock::
+	'$(REPOSITORY_UV_LITERAL)' pip compile '$(REPOSITORY_ROOT_LITERAL)/requirements.txt' --python-version 3.12 --python-platform x86_64-manylinux_2_28 --default-index https://pypi.org/simple --generate-hashes --custom-compile-command 'make lock' --output-file '$(REPOSITORY_ROOT_LITERAL)/requirements-py312.lock'
+	'$(REPOSITORY_UV_LITERAL)' pip compile '$(REPOSITORY_ROOT_LITERAL)/requirements.txt' --python-version 3.14 --python-platform x86_64-manylinux_2_28 --default-index https://pypi.org/simple --generate-hashes --custom-compile-command 'make lock' --output-file '$(REPOSITORY_ROOT_LITERAL)/requirements-py314.lock'
 
-verify: lint test build
+test::
+	PYTHONPATH='$(REPOSITORY_ROOT_LITERAL)' PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' -m unittest weather_notebook_tests
+	PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/check_weather_notebook_contracts.py'
 
-check: clean verify
-	$(MAKE) -C "$(ROOT)" clean
+build::
+	@/usr/bin/printf '%s\n' 'Notebook project: no build artifact to compile.'
+
+root-test::
+	/bin/sh '$(REPOSITORY_ROOT_LITERAL)/scripts/test-makefile-root.sh'
+
+verify:: root-test lint test build
+
+check:: clean verify
+	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete
+	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type d -name '__pycache__' -prune -exec /bin/rm -rf {} +
+endef
+
+$(eval $(REPOSITORY_PUBLIC_RECIPES))

--- a/README.md
+++ b/README.md
@@ -68,11 +68,17 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   fake-HTTP tests for pagination, payload validation, failure propagation,
   request bounds, and unit conversions.
 - `make check` runs `make verify` with bytecode cleanup before and after.
+- The Make entry points derive their root from the reviewed Makefile and reject
+  caller shell, startup-file, Makefile-list, unsafe-mode, executable Make
+  syntax, and later public-recipe replacement. `PYTHON` and `UV` remain
+  literal caller-selectable executables; `PATH` lookup for their defaults and
+  later GNU Make `override` directives are explicit trust boundaries.
 - GitHub Actions installs the exact scientific stack and runs offline contracts
   on every push, pull request, and manual dispatch for Python 3.12 and 3.14 on
   Ubuntu 24.04 with read-only permissions, immutable action pins,
   credential-free checkout, and cancellation for superseded runs.
-- The hosted matrix also reruns `make check` from an external working directory.
+- The hosted matrix invokes `/usr/bin/make` and reruns the full gate from an
+  external working directory.
 - `python3 scripts/check_weather_notebook_contracts.py` runs just the notebook contracts.
 - `python3 -m unittest weather_notebook_tests` runs the executable NOAA helper
   tests plus an offline synthetic flow through fake responses, date bucketing,

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -1,0 +1,47 @@
+# Isolate Make, Python, and uv Verification Authority
+
+## Status: Completed
+
+## Context
+
+The Makefile rooted checks, cleanup, and lock generation at its own location,
+but callers could still replace the recipe shell, load startup makefiles,
+override the Makefile list, select non-executing or error-ignoring modes,
+embed Make syntax in executable values, or append single-colon public recipes
+after the reviewed file.
+
+## Requirements
+
+- Derive the repository root only from the reviewed Makefile path.
+- Freeze literal Python and uv executable values without evaluating Make
+  syntax, including paths with spaces and shell metacharacters.
+- Fix ordinary public recipes to `/bin/sh`, reject injected startup files and
+  replaced Makefile lists, and reject unsafe execution modes.
+- Reject later single-colon replacement of every public target while
+  preserving documented caller-override boundaries.
+- Keep bytecode cleanup confined to the reviewed repository before and after
+  the full offline gate.
+- Exercise all eight public targets under command-line and environment root
+  and shell attacks, including fake offline lock generation.
+- Invoke hosted root and external verification through `/usr/bin/make`.
+
+## Scope Boundaries
+
+- Do not change NOAA request behavior, notebook contents, dependency pins,
+  lockfile bytes, or scientific output.
+- Keep `make lock` outside the default offline verification gate.
+- Caller-supplied GNU Make `override` directives and `PATH` selection of the
+  default `python3` and `uv` remain explicit trust boundaries.
+
+## Verification
+
+- Repository and external-directory `make check` passed 27 unit tests and 20
+  notebook contracts without loading a NOAA token or making a live request.
+- The authority harness passed 40 public-target/root/shell cases, six raw
+  Make-syntax controls, two Makefile-list rejections, two startup boundaries,
+  eight later recipe-replacement rejections, later root/Python/uv and shell
+  controls, PATH boundaries, cleanup containment, caller `MAKEFLAGS`, and ten
+  unsafe-mode rejections.
+- Python and shell syntax, workflow YAML, notebook JSON, lockfile digests,
+  `git diff --check`, intended-path, artifact, and changed-line credential
+  audits passed.

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -70,6 +70,9 @@ STABLE_RESULT_COUNT_PLAN_PATH = (
 JUPYTERLAB_SECURITY_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-20-jupyterlab-security-update.md"
 )
+MAKE_AUTHORITY_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-21-make-authority-isolation.md"
+)
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "check.yml"
 LOCKFILE_SHA256 = {
     "requirements-py312.lock": "b59381ed41e79c40080b1ec5f772559bcc26bf33fa746e3d242304c24142fa4c",
@@ -118,9 +121,9 @@ jobs:
       - name: Verify scientific stack imports
         run: python -c \"import jupyter, matplotlib, numpy, pandas, requests\"
       - name: Run repository checks
-        run: make check
+        run: /usr/bin/make check
       - name: Verify external working directory
-        run: cd \"$(mktemp -d)\" && make -f \"$GITHUB_WORKSPACE/Makefile\" check
+        run: cd \"$(mktemp -d)\" && /usr/bin/make -f \"$GITHUB_WORKSPACE/Makefile\" check
 """
 
 
@@ -564,6 +567,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(ANALYSIS_PROVENANCE_PLAN_PATH, "weather analysis provenance")
     assert_completed_plan(STABLE_RESULT_COUNT_PLAN_PATH, "stable NOAA result count")
     assert_completed_plan(JUPYTERLAB_SECURITY_PLAN_PATH, "JupyterLab security update")
+    assert_completed_plan(MAKE_AUTHORITY_PLAN_PATH, "Make authority isolation")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_synthetic_analysis_flow_is_exercised," in checker_main,
@@ -740,26 +744,78 @@ def test_dependency_and_ci_contracts():
 
     makefile = (ROOT / "Makefile").read_text()
     makefile_lines = set(makefile.splitlines())
+    for contract in (
+        ".DEFAULT_GOAL := check",
+        ".SECONDEXPANSION:",
+        "PYTHON ?= python3",
+        "override PYTHON := $(value PYTHON)",
+        "UV ?= uv",
+        "override UV := $(value UV)",
+        "override SHELL := /bin/sh",
+        "override .SHELLFLAGS := -c",
+        "override MAKEFILES :=",
+        "ifneq ($(origin MAKEFILE_LIST),file)",
+        "export ROOT",
+        "root-test::",
+        "\t/bin/sh '$(REPOSITORY_ROOT_LITERAL)/scripts/test-makefile-root.sh'",
+        "$(eval $(REPOSITORY_PUBLIC_RECIPES))",
+    ):
+        assert_true(contract in makefile_lines, "Makefile authority contract is missing {0!r}".format(contract))
+    assert_true("MAKEFLAGS must not be overridden" in makefile, "Makefile must reject caller MAKEFLAGS")
+    assert_true("MAKEFILES must be empty" in makefile, "Makefile must reject startup files")
+    assert_true("MAKEFILE_LIST must not be overridden" in makefile, "Makefile must reject Makefile-list replacement")
+    assert_true("PYTHON must be a literal executable path" in makefile, "Makefile must reject Python Make syntax")
+    assert_true("UV must be a literal executable path" in makefile, "Makefile must reject uv Make syntax")
     assert_true(
-        "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile_lines,
-        "Makefile must protect the repository resolved from its own path",
+        "'$(REPOSITORY_ROOT_LITERAL)/scripts/test-makefile-root.sh'" in makefile,
+        "Makefile must use the rooted authority harness",
     )
-    assert_true("PYTHON ?= python3" in makefile_lines, "Makefile must preserve the Python command override")
-    assert_true("$(ROOT)/scripts/check_weather_notebook_contracts.py" in makefile, "Makefile must use the rooted contract path")
-    assert_true('find "$(ROOT)"' in makefile, "Makefile cleanup must stay inside the repository")
-    assert_true('$(MAKE) -C "$(ROOT)" clean' in makefile, "recursive cleanup must stay rooted")
-    assert_true("$(PYTHON) -m unittest weather_notebook_tests" in makefile, "Makefile must run executable NOAA helper tests")
+    assert_true(
+        "scripts/check_weather_notebook_contracts.py" in makefile,
+        "Makefile must use the rooted notebook contract path",
+    )
+    assert_true(
+        "/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)'" in makefile,
+        "Makefile cleanup must stay inside the repository",
+    )
+    assert_true(
+        "PYTHONPATH='$(REPOSITORY_ROOT_LITERAL)' PYTHONDONTWRITEBYTECODE=1 "
+        "'$(REPOSITORY_PYTHON_LITERAL)' -m unittest weather_notebook_tests" in makefile,
+        "Makefile must run executable NOAA helper tests",
+    )
+    assert_true("verify:: root-test lint test build" in makefile_lines, "full verification must run authority tests")
     lock_command_template = (
-        'cd "$(ROOT)" && uv pip compile requirements.txt --python-version {python_version} '
+        "'$(REPOSITORY_UV_LITERAL)' pip compile '$(REPOSITORY_ROOT_LITERAL)/requirements.txt' "
+        "--python-version {python_version} "
         '--python-platform x86_64-manylinux_2_28 --default-index https://pypi.org/simple '
-        "--generate-hashes --custom-compile-command 'make lock' --output-file {lockfile}"
+        "--generate-hashes --custom-compile-command 'make lock' "
+        "--output-file '$(REPOSITORY_ROOT_LITERAL)/{lockfile}'"
     )
     for python_version, lockfile in (("3.12", "requirements-py312.lock"), ("3.14", "requirements-py314.lock")):
         assert_true(
             lock_command_template.format(python_version=python_version, lockfile=lockfile) in makefile,
             "Makefile must preserve the reviewed {0} lock command".format(python_version),
         )
-    assert_true(makefile.count("uv pip compile requirements.txt") == 2, "Makefile must define exactly two lock commands")
+    assert_true(
+        makefile.count(
+            "'$(REPOSITORY_UV_LITERAL)' pip compile '$(REPOSITORY_ROOT_LITERAL)/requirements.txt'"
+        ) == 2,
+        "Makefile must define exactly two frozen lock commands",
+    )
+
+    authority_test = (ROOT / "scripts" / "test-makefile-root.sh").read_text()
+    for contract in (
+        "40 target/authority cases",
+        "literal hostile Python and UV paths",
+        "6 raw Make-syntax controls",
+        "2 MAKEFILE_LIST rejections",
+        "2 startup-boundary cases",
+        "8 later recipe-replacement rejections",
+        "PATH-Python/PATH-UV boundary controls",
+        "cleanup containment",
+        "10 mode rejections",
+    ):
+        assert_true(contract in authority_test, "Make authority harness must include {0!r}".format(contract))
     assert_true(RUNTIME_MODULE.is_file(), "NOAA runtime helpers must be importable")
     assert_true(RUNTIME_TESTS.is_file(), "NOAA runtime helper tests must be checked in")
 

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env sh
+set -eu
+
+PATH=/usr/bin:/bin
+export PATH
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/weather-notebooks-make-authority-XXXXXX")
+trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
+unset MAKEFILES MAKEFILE_LIST MAKEFLAGS MFLAGS MAKEOVERRIDES PYTHON ROOT SHELL UV
+
+CONTROL_DIR="$TEMP_ROOT/control"
+CHECKOUT="$TEMP_ROOT/weather notebook's [gate] \"quoted\" \`touch WEATHER_ROOT_MARKER\`"
+ATTACKER_ROOT="$TEMP_ROOT/attacker"
+AUTHORITY_PATH="$TEMP_ROOT/no-unreviewed-tools"
+LOG="$TEMP_ROOT/commands.log"
+SHELL_LOG="$TEMP_ROOT/shell.log"
+mkdir -p "$CONTROL_DIR" "$CHECKOUT/scripts" "$ATTACKER_ROOT" "$AUTHORITY_PATH"
+CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && /bin/pwd -P)
+CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && /bin/pwd -P)
+MAKEFILE="$CHECKOUT/Makefile"
+cp "$ROOT_DIR/Makefile" "$MAKEFILE"
+
+FAKE_PYTHON="$TEMP_ROOT/trusted python's \"quoted\" \`touch WEATHER_PYTHON_MARKER\` \$literal"
+cat >"$FAKE_PYTHON" <<'SCRIPT'
+#!/bin/sh
+printf '%s|%s|%s\n' "$PWD" "$0" "$*" >> "$WEATHER_COMMAND_LOG"
+SCRIPT
+chmod +x "$FAKE_PYTHON"
+for script in weather_notebook.py weather_notebook_tests.py scripts/check_weather_notebook_contracts.py scripts/test-makefile-root.sh; do
+  mkdir -p "$CHECKOUT/$(dirname -- "$script")"
+  cp "$FAKE_PYTHON" "$CHECKOUT/$script"
+done
+
+FAKE_UV="$TEMP_ROOT/trusted uv's \"quoted\" \`touch WEATHER_UV_MARKER\` \$literal"
+cat >"$FAKE_UV" <<'SCRIPT'
+#!/bin/sh
+printf '%s|%s|%s\n' "$PWD" "$0" "$*" >> "$WEATHER_COMMAND_LOG"
+SCRIPT
+chmod +x "$FAKE_UV"
+
+FAKE_SHELL="$TEMP_ROOT/fake-shell"
+printf '#!/bin/sh\nprintf invoked >> %s\nexec /bin/sh "$@"\n' "'$SHELL_LOG'" >"$FAKE_SHELL"
+chmod +x "$FAKE_SHELL"
+
+run_case() {
+  target=$1
+  mode=$2
+  output="$TEMP_ROOT/case.out"
+  rm -f "$LOG" "$SHELL_LOG" "$output"
+  : >"$CHECKOUT/probe.pyc"
+  : >"$ATTACKER_ROOT/keep.pyc"
+  set +e
+  case "$mode" in
+    default) (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" "$target") >"$output" 2>&1 ;;
+    command-root) (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" ROOT="$ATTACKER_ROOT" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" "$target") >"$output" 2>&1 ;;
+    environment-root) (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" ROOT="$ATTACKER_ROOT" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" "$target") >"$output" 2>&1 ;;
+    command-shell) (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" SHELL="$FAKE_SHELL" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" "$target") >"$output" 2>&1 ;;
+    environment-shell) (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" SHELL="$FAKE_SHELL" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" "$target") >"$output" 2>&1 ;;
+  esac
+  status=$?
+  set -e
+  if [ "$status" -ne 0 ] || [ -e "$SHELL_LOG" ] || [ ! -e "$ATTACKER_ROOT/keep.pyc" ]; then
+    printf 'authority case failed: target=%s mode=%s status=%s\n' "$target" "$mode" "$status" >&2
+    cat "$output" >&2
+    return 1
+  fi
+  case "$target" in
+    clean) [ ! -e "$CHECKOUT/probe.pyc" ] ;;
+    build) grep -Fq 'Notebook project: no build artifact to compile.' "$output" ;;
+    *) grep -Fq "$CHECKOUT" "$LOG" ;;
+  esac
+}
+
+executed=0
+for target in build check clean lint lock root-test test verify; do
+  for mode in default command-root environment-root command-shell environment-shell; do
+    run_case "$target" "$mode"
+    executed=$((executed + 1))
+  done
+done
+[ "$executed" -eq 40 ]
+
+rm -f "$LOG"
+(cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" check) >/dev/null 2>&1
+grep -Fq "$FAKE_PYTHON" "$LOG"
+(cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" lock) >/dev/null 2>&1
+grep -Fq "$FAKE_UV" "$LOG"
+[ ! -e "$CONTROL_DIR/WEATHER_ROOT_MARKER" ]
+[ ! -e "$CONTROL_DIR/WEATHER_PYTHON_MARKER" ]
+[ ! -e "$CONTROL_DIR/WEATHER_UV_MARKER" ]
+
+PYTHON_MARK="$TEMP_ROOT/python-syntax"
+PYTHON_BAD="\$(shell /usr/bin/touch '$PYTHON_MARK')"
+if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" /usr/bin/make --no-print-directory -f "$MAKEFILE" "PYTHON=$PYTHON_BAD" lint) >"$TEMP_ROOT/python.out" 2>&1; then exit 1; fi
+[ ! -e "$PYTHON_MARK" ]
+PYTHON_ENV_MARK="$TEMP_ROOT/python-environment-syntax"
+PYTHON_ENV_BAD="\$(shell /usr/bin/touch '$PYTHON_ENV_MARK')"
+if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" PYTHON="$PYTHON_ENV_BAD" /usr/bin/make --environment-overrides --no-print-directory -f "$MAKEFILE" lint) >"$TEMP_ROOT/python-environment.out" 2>&1; then exit 1; fi
+[ ! -e "$PYTHON_ENV_MARK" ]
+
+ROOT_MARK="$TEMP_ROOT/root-syntax"
+ROOT_BAD="\$(shell /usr/bin/touch '$ROOT_MARK')"
+(cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" "ROOT=$ROOT_BAD" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" lint) >"$TEMP_ROOT/root.out" 2>&1
+[ ! -e "$ROOT_MARK" ]
+ROOT_ENV_MARK="$TEMP_ROOT/root-environment-syntax"
+ROOT_ENV_BAD="\$(shell /usr/bin/touch '$ROOT_ENV_MARK')"
+(cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" ROOT="$ROOT_ENV_BAD" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --environment-overrides --no-print-directory -f "$MAKEFILE" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" lint) >"$TEMP_ROOT/root-environment.out" 2>&1
+[ ! -e "$ROOT_ENV_MARK" ]
+
+UV_MARK="$TEMP_ROOT/uv-syntax"
+UV_BAD="\$(shell /usr/bin/touch '$UV_MARK')"
+if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" /usr/bin/make --no-print-directory -f "$MAKEFILE" "UV=$UV_BAD" lock) >"$TEMP_ROOT/uv.out" 2>&1; then exit 1; fi
+[ ! -e "$UV_MARK" ]
+UV_ENV_MARK="$TEMP_ROOT/uv-environment-syntax"
+UV_ENV_BAD="\$(shell /usr/bin/touch '$UV_ENV_MARK')"
+if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" UV="$UV_ENV_BAD" /usr/bin/make --environment-overrides --no-print-directory -f "$MAKEFILE" lock) >"$TEMP_ROOT/uv-environment.out" 2>&1; then exit 1; fi
+[ ! -e "$UV_ENV_MARK" ]
+
+if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" /usr/bin/make --no-print-directory -f "$MAKEFILE" MAKEFILE_LIST="$MAKEFILE" check) >"$TEMP_ROOT/makefile-list-command" 2>&1; then exit 1; fi
+grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/makefile-list-command"
+if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" MAKEFILE_LIST="$MAKEFILE" /usr/bin/make --environment-overrides --no-print-directory -f "$MAKEFILE" check) >"$TEMP_ROOT/makefile-list-environment" 2>&1; then exit 1; fi
+grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/makefile-list-environment"
+
+STARTUP_MAKE="$TEMP_ROOT/startup.mk"
+printf 'STARTUP_LOADED := yes\n' >"$STARTUP_MAKE"
+if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" MAKEFILES="$STARTUP_MAKE" /usr/bin/make --no-print-directory -f "$MAKEFILE" check) >"$TEMP_ROOT/startup-environment" 2>&1; then exit 1; fi
+grep -Fq 'MAKEFILES must be empty' "$TEMP_ROOT/startup-environment"
+if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" /usr/bin/make --no-print-directory -f "$MAKEFILE" "MAKEFILES=$STARTUP_MAKE" check) >"$TEMP_ROOT/startup-command" 2>&1; then exit 1; fi
+grep -Fq 'MAKEFILES must be empty' "$TEMP_ROOT/startup-command"
+
+for target in build check clean lint lock root-test test verify; do
+  later="$TEMP_ROOT/later-$target.mk"
+  printf '%s:\n\t/usr/bin/touch %s\n' "$target" "$TEMP_ROOT/replaced-$target" >"$later"
+  if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" /usr/bin/make --no-print-directory -f "$MAKEFILE" -f "$later" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" "$target") >"$TEMP_ROOT/later-$target.out" 2>&1; then exit 1; fi
+  [ ! -e "$TEMP_ROOT/replaced-$target" ]
+done
+
+TARGET_PYTHON="$TEMP_ROOT/target-python"
+TARGET_UV="$TEMP_ROOT/target-uv"
+TARGET_PYTHON_LOG="$TEMP_ROOT/target-python.log"
+TARGET_UV_LOG="$TEMP_ROOT/target-uv.log"
+cat >"$TARGET_PYTHON" <<'SCRIPT'
+#!/bin/sh
+printf '%s\n' "$*" >> "$WEATHER_TARGET_PYTHON_LOG"
+exit 1
+SCRIPT
+cat >"$TARGET_UV" <<'SCRIPT'
+#!/bin/sh
+printf '%s\n' "$*" >> "$WEATHER_TARGET_UV_LOG"
+exit 1
+SCRIPT
+chmod +x "$TARGET_PYTHON" "$TARGET_UV"
+LATER_ROOT_MARKER="$TEMP_ROOT/later-root-marker"
+LATER_VARS="$TEMP_ROOT/later-vars.mk"
+mkdir -p "$ATTACKER_ROOT/scripts"
+cat >"$ATTACKER_ROOT/scripts/test-makefile-root.sh" <<'SCRIPT'
+#!/bin/sh
+/usr/bin/touch "$WEATHER_LATER_ROOT_MARKER"
+SCRIPT
+chmod +x "$ATTACKER_ROOT/scripts/test-makefile-root.sh"
+cat >"$LATER_VARS" <<LATER_MAKE
+build check clean lint lock root-test test verify: MAKEFILE_LIST := $MAKEFILE
+build check clean lint lock root-test test verify: ROOT := $ATTACKER_ROOT
+build check clean lint lock root-test test verify: PYTHON := $TARGET_PYTHON
+build check clean lint lock root-test test verify: UV := $TARGET_UV
+LATER_MAKE
+rm -f "$LOG" "$LATER_ROOT_MARKER" "$TARGET_PYTHON_LOG" "$TARGET_UV_LOG"
+(cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" WEATHER_LATER_ROOT_MARKER="$LATER_ROOT_MARKER" WEATHER_TARGET_PYTHON_LOG="$TARGET_PYTHON_LOG" WEATHER_TARGET_UV_LOG="$TARGET_UV_LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" -f "$LATER_VARS" root-test "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV") >"$TEMP_ROOT/later-root" 2>&1
+grep -Fq "$CHECKOUT" "$LOG"
+[ ! -e "$LATER_ROOT_MARKER" ]
+rm -f "$LOG"
+(cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" -f "$LATER_VARS" lint "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV") >"$TEMP_ROOT/later-python" 2>&1
+grep -Fq "$FAKE_PYTHON" "$LOG"
+rm -f "$LOG"
+(cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" -f "$LATER_VARS" lock "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV") >"$TEMP_ROOT/later-uv" 2>&1
+grep -Fq "$FAKE_UV" "$LOG"
+
+LATER_SHELL="$TEMP_ROOT/later-shell.mk"
+LATER_SHELL_LOG="$TEMP_ROOT/later-shell.log"
+LATER_FAKE_SHELL="$TEMP_ROOT/later-fake-shell"
+cat >"$LATER_FAKE_SHELL" <<'SCRIPT'
+#!/bin/sh
+printf '%s\n' "$*" >> "$WEATHER_LATER_SHELL_LOG"
+printf '%s\n' ok
+exit 0
+SCRIPT
+chmod +x "$LATER_FAKE_SHELL"
+cat >"$LATER_SHELL" <<LATER_SHELL_MAKE
+build check clean lint lock root-test test verify: MAKEFILE_LIST := $MAKEFILE
+build check clean lint lock root-test test verify: SHELL := $LATER_FAKE_SHELL
+build check clean lint lock root-test test verify: .SHELLFLAGS := -c
+LATER_SHELL_MAKE
+rm -f "$LOG" "$LATER_SHELL_LOG"
+(cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" WEATHER_LATER_SHELL_LOG="$LATER_SHELL_LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" -f "$LATER_SHELL" check "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV") >"$TEMP_ROOT/later-shell" 2>&1
+grep -Fq "$CHECKOUT" "$LOG"
+[ ! -e "$LATER_SHELL_LOG" ]
+
+LATER_OVERRIDE="$TEMP_ROOT/later-override.mk"
+cat >"$LATER_OVERRIDE" <<LATER_OVERRIDE_MAKE
+build check clean lint lock root-test test verify: MAKEFILE_LIST := $MAKEFILE
+build check clean lint lock root-test test verify: override SHELL := $LATER_FAKE_SHELL
+build check clean lint lock root-test test verify: override .SHELLFLAGS := -c
+LATER_OVERRIDE_MAKE
+rm -f "$LATER_SHELL_LOG"
+(cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_LATER_SHELL_LOG="$LATER_SHELL_LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" -f "$LATER_OVERRIDE" check "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV") >"$TEMP_ROOT/later-override" 2>&1
+[ -s "$LATER_SHELL_LOG" ]
+
+PATH_PYTHON="$TEMP_ROOT/python3"
+PATH_PYTHON_LOG="$TEMP_ROOT/path-python.log"
+cp "$FAKE_PYTHON" "$PATH_PYTHON"
+rm -f "$PATH_PYTHON_LOG"
+(cd "$CONTROL_DIR" && PATH="$TEMP_ROOT:/usr/bin:/bin" WEATHER_COMMAND_LOG="$PATH_PYTHON_LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" lint "UV=$FAKE_UV") >"$TEMP_ROOT/path-python" 2>&1
+[ -s "$PATH_PYTHON_LOG" ]
+
+PATH_UV="$TEMP_ROOT/uv"
+PATH_UV_LOG="$TEMP_ROOT/path-uv.log"
+cp "$FAKE_UV" "$PATH_UV"
+rm -f "$PATH_UV_LOG"
+(cd "$CONTROL_DIR" && PATH="$TEMP_ROOT:/usr/bin:/bin" WEATHER_COMMAND_LOG="$PATH_UV_LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" lock "PYTHON=$FAKE_PYTHON") >"$TEMP_ROOT/path-uv" 2>&1
+[ -s "$PATH_UV_LOG" ]
+
+if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" /usr/bin/make --no-print-directory -f "$MAKEFILE" MAKEFLAGS=-n check) >"$TEMP_ROOT/flags" 2>&1; then exit 1; fi
+grep -Fq 'MAKEFLAGS must not be overridden' "$TEMP_ROOT/flags"
+for flag in -n --just-print --dry-run --recon -t --touch -q --question -i --ignore-errors; do
+  if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" /usr/bin/make "$flag" --no-print-directory -f "$MAKEFILE" check) >"$TEMP_ROOT/flag" 2>&1; then exit 1; fi
+  grep -Fq 'non-executing or error-ignoring MAKEFLAGS are not supported' "$TEMP_ROOT/flag"
+done
+
+printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python and UV paths, 6 raw Make-syntax controls, 2 MAKEFILE_LIST rejections, 2 startup-boundary cases, 8 later recipe-replacement rejections, later root/Python/UV and non-override shell protection, override/startup/PATH-Python/PATH-UV boundary controls, cleanup containment, caller MAKEFLAGS rejection, and 10 mode rejections'


### PR DESCRIPTION
## Summary

Isolate repository verification and lock generation from caller-controlled Make roots, shells, startup files, Makefile lists, unsafe execution modes, executable Make syntax, and later public-recipe replacement. Preserve the existing offline NOAA notebook gate, hash-locked dependency graphs, and caller-directory-independent workflow while making local and hosted entry points use the same reviewed authority boundary.

## Baseline

- `make check` already passed 27 executable NOAA helper tests and 20 static notebook, dependency, and workflow contracts.
- The Makefile rooted checks, cleanup, and lock generation at its own location, but callers could still influence recipes through Make startup inputs, shell and Makefile-list overrides, unsafe modes, executable values containing Make syntax, and later single-colon targets.
- Hosted root and external checks selected `make` through `PATH`.
- Both reviewed lockfiles and the notebook were clean and byte-stable before the change.

## Improvements

- **Tests:** Add an executable authority harness covering all eight public targets across 40 root/shell cases, literal hostile Python and uv paths, startup and Makefile-list boundaries, later recipe replacement, cleanup containment, PATH boundaries, and unsafe modes.
- **CI:** Invoke root and external verification through `/usr/bin/make` while preserving the Python 3.12 and 3.14 hash-locked matrix.
- **Security:** Freeze literal Python and uv values, reject executable Make syntax and unsafe `MAKEFLAGS`, and prevent ordinary caller shell/root/startup-file authority from replacing reviewed verification or lock behavior.
- **Architecture:** Consolidate public Make targets behind a fixed repository authority prerequisite and root Python inputs explicitly without depending on caller working directories.
- **Documentation:** Document the authority guarantees, scope boundaries, verification evidence, and changelog entry.
- **Developer experience:** Preserve `make lock`, external absolute-Makefile invocation, offline `make check`, and explicit `PATH`/GNU Make `override` trust boundaries.

## Validation

- `./scripts/test-makefile-root.sh` - passed 40 target/root/shell cases and all additional authority boundaries.
- `/usr/bin/make check` from the repository root - passed 27 unit tests and 20 notebook contracts.
- `/usr/bin/make -f /tmp/weather-notebooks-master-exact-20260621T1057/Makefile check` from an external directory - passed the same complete gate.
- Eleven focused hostile static mutations - all rejected, including delayed recipe expansion that would break literal-dollar executable paths.
- `/bin/sh -n scripts/test-makefile-root.sh` and in-memory Python compilation - passed.
- Workflow YAML and notebook JSON - parsed successfully; the notebook has no saved outputs or execution counts.
- `requirements-py312.lock` and `requirements-py314.lock` retained SHA-256 values `b59381ed…` and `f4346cb4…` respectively.
- `git diff --check`, `git fsck --strict --no-dangling`, artifact scan, intended-path audit, merge-marker scan, and changed-line credential scan - passed.
- Exact local and remote branch head - `02093e43e90160d85e71cfa9c066a6f960112230`.

## Risk

- No NOAA request behavior, notebook cell, dependency pin, lockfile byte, scientific output, or public Python API is changed.
- No NOAA token was loaded and no live provider request was sent; validation remains offline by design.
- No interactive Jupyter browser session was exercised; notebook JSON, imports, unit tests, and offline contracts define the validated boundary.
- Caller-supplied GNU Make `override` directives and `PATH` selection of default `python3` and `uv` remain documented trust boundaries.

## Follow-Ups

- Review the hosted Python 3.12 and 3.14 jobs plus CodeQL at this exact head.
- Exercise an interactive notebook session separately when browser-level behavior changes in a future pull request.
