### PR TITLE
fix: clarify weather notebook Make boundaries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Isolated Make verification authority from caller-controlled roots, shells,
   startup files, Makefile lists, unsafe modes, executable Make syntax, and
   later single-colon public recipe replacement.
+- Documented caller-added double-colon public recipes and startup parse-time Make code as outside the local Make trust boundary.
 - Added literal Python/uv, lock-command, cleanup-containment, and external-root
   authority coverage and invoked hosted verification through `/usr/bin/make`.
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ override MAKEFILES :=
 ifneq ($(origin MAKEFILE_LIST),file)
 $(error MAKEFILE_LIST must not be overridden)
 endif
-override ROOT := $(shell path='$(subst ','"'"',$(value MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+override REPOSITORY_SED := $(shell if [ -x /usr/bin/sed ]; then /usr/bin/printf '%s' /usr/bin/sed; elif [ -x /bin/sed ]; then /usr/bin/printf '%s' /bin/sed; fi)
+override ROOT := $(shell path='$(subst ','"'"',$(value MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | '$(REPOSITORY_SED)' 's/^ //'); [ -f "$$path" ] || exit 1; directory=$${path%/*}; [ "$$directory" != "$$path" ] || directory=.; CDPATH= cd -- "$$directory" && /bin/pwd -P)
 export ROOT
 ifeq ($(strip $(ROOT)),)
 $(error repository Makefile path could not be resolved)
@@ -62,7 +63,7 @@ override REPOSITORY_PYTHON_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(PYTHON))
 override REPOSITORY_UV_LITERAL := $(call REPOSITORY_SHELL_LITERAL,$(UV))
 
 build check clean lint lock root-test test verify:: $$(if $$(filter file,$$(origin MAKEFILE_LIST)),,$$(error MAKEFILE_LIST must not be overridden))
-build check clean lint lock root-test test verify:: $$(if $$(shell path=$$$$(/usr/bin/printf '%s' '$$(subst ','"'"',$$(MAKEFILE_LIST))' | /usr/bin/sed 's/^ //') && [ -f "$$$$path" ] && /usr/bin/printf '%s' ok),,$$(error repository Makefile must be loaded alone))
+build check clean lint lock root-test test verify:: $$(if $$(shell path=$$$$(/usr/bin/printf '%s' '$$(subst ','"'"',$$(MAKEFILE_LIST))' | '$$(REPOSITORY_SED)' 's/^ //') && [ -f "$$$$path" ] && /usr/bin/printf '%s' ok),,$$(error repository Makefile must be loaded alone))
 build check clean lint lock root-test test verify:: __repository-make-authority
 
 __repository-make-authority::
@@ -74,15 +75,15 @@ clean::
 	/usr/bin/find '$(REPOSITORY_ROOT_LITERAL)' -type d -name '__pycache__' -prune -exec /bin/rm -rf {} +
 
 lint::
-	PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' -m py_compile '$(REPOSITORY_ROOT_LITERAL)/weather_notebook.py' '$(REPOSITORY_ROOT_LITERAL)/weather_notebook_tests.py' '$(REPOSITORY_ROOT_LITERAL)/scripts/check_weather_notebook_contracts.py'
+	PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' -I -B -m py_compile '$(REPOSITORY_ROOT_LITERAL)/weather_notebook.py' '$(REPOSITORY_ROOT_LITERAL)/weather_notebook_tests.py' '$(REPOSITORY_ROOT_LITERAL)/scripts/check_weather_notebook_contracts.py'
 
 lock::
 	'$(REPOSITORY_UV_LITERAL)' pip compile '$(REPOSITORY_ROOT_LITERAL)/requirements.txt' --python-version 3.12 --python-platform x86_64-manylinux_2_28 --default-index https://pypi.org/simple --generate-hashes --custom-compile-command 'make lock' --output-file '$(REPOSITORY_ROOT_LITERAL)/requirements-py312.lock'
 	'$(REPOSITORY_UV_LITERAL)' pip compile '$(REPOSITORY_ROOT_LITERAL)/requirements.txt' --python-version 3.14 --python-platform x86_64-manylinux_2_28 --default-index https://pypi.org/simple --generate-hashes --custom-compile-command 'make lock' --output-file '$(REPOSITORY_ROOT_LITERAL)/requirements-py314.lock'
 
 test::
-	PYTHONPATH='$(REPOSITORY_ROOT_LITERAL)' PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' -m unittest weather_notebook_tests
-	PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' '$(REPOSITORY_ROOT_LITERAL)/scripts/check_weather_notebook_contracts.py'
+	cd '$(REPOSITORY_ROOT_LITERAL)' && PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' -I -B -c 'import runpy, sys; sys.path.insert(0, "."); runpy.run_path("weather_notebook_tests.py", run_name="__main__")'
+	PYTHONDONTWRITEBYTECODE=1 '$(REPOSITORY_PYTHON_LITERAL)' -I -B '$(REPOSITORY_ROOT_LITERAL)/scripts/check_weather_notebook_contracts.py'
 
 build::
 	@/usr/bin/printf '%s\n' 'Notebook project: no build artifact to compile.'

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   syntax, and later public-recipe replacement. `PYTHON` and `UV` remain
   literal caller-selectable executables; `PATH` lookup for their defaults and
   later GNU Make `override` directives are explicit trust boundaries.
+- Caller-supplied double-colon public recipes and startup makefile parse-time code are outside the local Make trust boundary.
 - GitHub Actions installs the exact scientific stack and runs offline contracts
   on every push, pull request, and manual dispatch for Python 3.12 and 3.14 on
   Ubuntu 24.04 with read-only permissions, immutable action pins,

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -9,6 +9,7 @@ but callers could still replace the recipe shell, load startup makefiles,
 override the Makefile list, select non-executing or error-ignoring modes,
 embed Make syntax in executable values, or append single-colon public recipes
 after the reviewed file.
+Startup makefiles can run parse-time Make functions before the repository Makefile rejects them.
 
 ## Requirements
 
@@ -30,6 +31,7 @@ after the reviewed file.
 - Do not change NOAA request behavior, notebook contents, dependency pins,
   lockfile bytes, or scientific output.
 - Keep `make lock` outside the default offline verification gate.
+- Caller-supplied double-colon public recipes and startup makefile parse-time code are outside the local Make trust boundary.
 - Caller-supplied GNU Make `override` directives and `PATH` selection of the
   default `python3` and `uv` remain explicit trust boundaries.
 
@@ -38,10 +40,11 @@ after the reviewed file.
 - Repository and external-directory `make check` passed 27 unit tests and 20
   notebook contracts without loading a NOAA token or making a live request.
 - The authority harness passed 40 public-target/root/shell cases, six raw
-  Make-syntax controls, two Makefile-list rejections, two startup boundaries,
-  eight later recipe-replacement rejections, later root/Python/uv and shell
-  controls, PATH boundaries, cleanup containment, caller `MAKEFLAGS`, and ten
-  unsafe-mode rejections.
+  Make-syntax controls, two Makefile-list rejections, two startup parse-time
+  boundary reproductions, eight later single-colon replacement rejections,
+  eight later double-colon append boundary reproductions, later root/Python/uv
+  and shell controls, PATH boundaries, cleanup containment, caller
+  `MAKEFLAGS`, and ten unsafe-mode rejections.
 - Python and shell syntax, workflow YAML, notebook JSON, lockfile digests,
   `git diff --check`, intended-path, artifact, and changed-line credential
   audits passed.

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -809,8 +809,9 @@ def test_dependency_and_ci_contracts():
         "literal hostile Python and UV paths",
         "6 raw Make-syntax controls",
         "2 MAKEFILE_LIST rejections",
-        "2 startup-boundary cases",
-        "8 later recipe-replacement rejections",
+        "2 startup parse-time boundary reproductions",
+        "8 later single-colon replacement rejections",
+        "8 later double-colon append boundary reproductions",
         "PATH-Python/PATH-UV boundary controls",
         "cleanup containment",
         "10 mode rejections",
@@ -824,6 +825,16 @@ def test_dependency_and_ci_contracts():
             "GitHub Actions" in (ROOT / docs_file).read_text(),
             "{0} must document the GitHub Actions baseline".format(docs_file),
         )
+    docs_text = "\n".join(
+        (ROOT / docs_file).read_text()
+        for docs_file in ("README.md", "CHANGES.md", "docs/plans/2026-06-21-make-authority-isolation.md")
+    )
+    for phrase in (
+        "Caller-supplied double-colon public recipes and startup makefile parse-time code are outside the local Make trust boundary.",
+        "Documented caller-added double-colon public recipes and startup parse-time Make code as outside the local Make trust boundary.",
+        "Startup makefiles can run parse-time Make functions before the repository Makefile rejects them.",
+    ):
+        assert_true(phrase in docs_text, "Make boundary documentation must include {0!r}".format(phrase))
 
 
 def main():

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -779,8 +779,9 @@ def test_dependency_and_ci_contracts():
         "Makefile cleanup must stay inside the repository",
     )
     assert_true(
-        "PYTHONPATH='$(REPOSITORY_ROOT_LITERAL)' PYTHONDONTWRITEBYTECODE=1 "
-        "'$(REPOSITORY_PYTHON_LITERAL)' -m unittest weather_notebook_tests" in makefile,
+        "'$(REPOSITORY_PYTHON_LITERAL)' -I -B -c "
+        "'import runpy, sys; sys.path.insert(0, \".\"); "
+        "runpy.run_path(\"weather_notebook_tests.py\", run_name=\"__main__\")'" in makefile,
         "Makefile must run executable NOAA helper tests",
     )
     assert_true("verify:: root-test lint test build" in makefile_lines, "full verification must run authority tests")

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -3,7 +3,7 @@ set -eu
 
 PATH=/usr/bin:/bin
 export PATH
-ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
 TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/weather-notebooks-make-authority-XXXXXX")
 trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
 unset MAKEFILES MAKEFILE_LIST MAKEFLAGS MFLAGS MAKEOVERRIDES PYTHON ROOT SHELL UV
@@ -15,10 +15,23 @@ AUTHORITY_PATH="$TEMP_ROOT/no-unreviewed-tools"
 LOG="$TEMP_ROOT/commands.log"
 SHELL_LOG="$TEMP_ROOT/shell.log"
 mkdir -p "$CONTROL_DIR" "$CHECKOUT/scripts" "$ATTACKER_ROOT" "$AUTHORITY_PATH"
-CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && /bin/pwd -P)
-CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && /bin/pwd -P)
+CONTROL_DIR=$(CDPATH='' cd -- "$CONTROL_DIR" && /bin/pwd -P)
+CHECKOUT=$(CDPATH='' cd -- "$CHECKOUT" && /bin/pwd -P)
 MAKEFILE="$CHECKOUT/Makefile"
 cp "$ROOT_DIR/Makefile" "$MAKEFILE"
+
+require_text() {
+  file=$1
+  text=$2
+  if ! grep -Fq "$text" "$ROOT_DIR/$file"; then
+    printf '%s must document Make boundary: %s\n' "$file" "$text" >&2
+    exit 1
+  fi
+}
+
+require_text README.md 'Caller-supplied double-colon public recipes and startup makefile parse-time code are outside the local Make trust boundary.'
+require_text CHANGES.md 'Documented caller-added double-colon public recipes and startup parse-time Make code as outside the local Make trust boundary.'
+require_text docs/plans/2026-06-21-make-authority-isolation.md 'Startup makefiles can run parse-time Make functions before the repository Makefile rejects them.'
 
 FAKE_PYTHON="$TEMP_ROOT/trusted python's \"quoted\" \`touch WEATHER_PYTHON_MARKER\` \$literal"
 cat >"$FAKE_PYTHON" <<'SCRIPT'
@@ -122,17 +135,37 @@ if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" MAKEFILE_LIST="$MAKEFILE" /usr/b
 grep -Fq 'MAKEFILE_LIST must not be overridden' "$TEMP_ROOT/makefile-list-environment"
 
 STARTUP_MAKE="$TEMP_ROOT/startup.mk"
-printf 'STARTUP_LOADED := yes\n' >"$STARTUP_MAKE"
+STARTUP_ENV_MARKER="$TEMP_ROOT/startup-environment-marker"
+STARTUP_COMMAND_MARKER="$TEMP_ROOT/startup-command-marker"
+printf '%s\n' "\$(shell /usr/bin/touch '$STARTUP_ENV_MARKER')" >"$STARTUP_MAKE"
 if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" MAKEFILES="$STARTUP_MAKE" /usr/bin/make --no-print-directory -f "$MAKEFILE" check) >"$TEMP_ROOT/startup-environment" 2>&1; then exit 1; fi
 grep -Fq 'MAKEFILES must be empty' "$TEMP_ROOT/startup-environment"
+[ -e "$STARTUP_ENV_MARKER" ]
+printf '%s\n' "\$(shell /usr/bin/touch '$STARTUP_COMMAND_MARKER')" >"$STARTUP_MAKE"
 if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" /usr/bin/make --no-print-directory -f "$MAKEFILE" "MAKEFILES=$STARTUP_MAKE" check) >"$TEMP_ROOT/startup-command" 2>&1; then exit 1; fi
 grep -Fq 'MAKEFILES must be empty' "$TEMP_ROOT/startup-command"
+[ -e "$STARTUP_COMMAND_MARKER" ]
 
 for target in build check clean lint lock root-test test verify; do
   later="$TEMP_ROOT/later-$target.mk"
   printf '%s:\n\t/usr/bin/touch %s\n' "$target" "$TEMP_ROOT/replaced-$target" >"$later"
   if (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" /usr/bin/make --no-print-directory -f "$MAKEFILE" -f "$later" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" "$target") >"$TEMP_ROOT/later-$target.out" 2>&1; then exit 1; fi
   [ ! -e "$TEMP_ROOT/replaced-$target" ]
+done
+
+for target in build check clean lint lock root-test test verify; do
+  later_append="$TEMP_ROOT/later-append-$target.mk"
+  append_marker="$TEMP_ROOT/appended-$target"
+  printf 'build check clean lint lock root-test test verify: MAKEFILE_LIST := %s\n' "$MAKEFILE" >"$later_append"
+  printf '%s::\n\t@/usr/bin/touch %s\n' "$target" "$append_marker" >>"$later_append"
+  rm -f "$LOG" "$append_marker"
+  (cd "$CONTROL_DIR" && PATH="$AUTHORITY_PATH" WEATHER_COMMAND_LOG="$LOG" /usr/bin/make --no-print-directory -f "$MAKEFILE" -f "$later_append" "PYTHON=$FAKE_PYTHON" "UV=$FAKE_UV" "$target") >"$TEMP_ROOT/later-append-$target.out" 2>&1
+  [ -e "$append_marker" ]
+  case "$target" in
+    build) grep -Fq 'Notebook project: no build artifact to compile.' "$TEMP_ROOT/later-append-$target.out" ;;
+    clean) : ;;
+    *) grep -Fq "$CHECKOUT" "$LOG" ;;
+  esac
 done
 
 TARGET_PYTHON="$TEMP_ROOT/target-python"
@@ -226,4 +259,4 @@ for flag in -n --just-print --dry-run --recon -t --touch -q --question -i --igno
   grep -Fq 'non-executing or error-ignoring MAKEFLAGS are not supported' "$TEMP_ROOT/flag"
 done
 
-printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python and UV paths, 6 raw Make-syntax controls, 2 MAKEFILE_LIST rejections, 2 startup-boundary cases, 8 later recipe-replacement rejections, later root/Python/UV and non-override shell protection, override/startup/PATH-Python/PATH-UV boundary controls, cleanup containment, caller MAKEFLAGS rejection, and 10 mode rejections'
+printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python and UV paths, 6 raw Make-syntax controls, 2 MAKEFILE_LIST rejections, 2 startup parse-time boundary reproductions, 8 later single-colon replacement rejections, 8 later double-colon append boundary reproductions, later root/Python/UV and non-override shell protection, override/startup/PATH-Python/PATH-UV boundary controls, cleanup containment, caller MAKEFLAGS rejection, and 10 mode rejections'

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 set -eu
 
+HOST_PYTHON=${PYTHON:-python3}
+case $HOST_PYTHON in */*) ;; *) HOST_PYTHON=$(command -v "$HOST_PYTHON") ;; esac
 PATH=/usr/bin:/bin
 export PATH
 ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
@@ -259,4 +261,12 @@ for flag in -n --just-print --dry-run --recon -t --touch -q --question -i --igno
   grep -Fq 'non-executing or error-ignoring MAKEFLAGS are not supported' "$TEMP_ROOT/flag"
 done
 
-printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python and UV paths, 6 raw Make-syntax controls, 2 MAKEFILE_LIST rejections, 2 startup parse-time boundary reproductions, 8 later single-colon replacement rejections, 8 later double-colon append boundary reproductions, later root/Python/UV and non-override shell protection, override/startup/PATH-Python/PATH-UV boundary controls, cleanup containment, caller MAKEFLAGS rejection, and 10 mode rejections'
+ISOLATION_DIR="$TEMP_ROOT/pythonpath"; ISOLATION_MARKER="$TEMP_ROOT/pythonpath-ran"; mkdir -p "$ISOLATION_DIR"
+cat >"$ISOLATION_DIR/sitecustomize.py" <<'PYTHON'
+import os
+open(os.environ["WEATHER_PYTHONPATH_MARKER"], "w").close()
+os._exit(0)
+PYTHON
+(cd "$CONTROL_DIR" && PYTHONPATH="$ISOLATION_DIR" WEATHER_PYTHONPATH_MARKER="$ISOLATION_MARKER" /usr/bin/make --no-print-directory -f "$ROOT_DIR/Makefile" "PYTHON=$HOST_PYTHON" lint) >"$TEMP_ROOT/pythonpath.out" 2>&1
+[ ! -e "$ISOLATION_MARKER" ]
+printf '%s\n' 'Make authority tests passed: 40 target/authority cases, literal hostile Python and UV paths, 6 raw Make-syntax controls, 2 MAKEFILE_LIST rejections, 2 startup parse-time boundary reproductions, 8 later single-colon replacement rejections, 8 later double-colon append boundary reproductions, later root/Python/UV and non-override shell protection, override/startup/PATH-Python/PATH-UV boundary controls, cleanup containment, caller MAKEFLAGS rejection, 10 mode rejections, and 1 hostile PYTHONPATH runtime gate'


### PR DESCRIPTION
## Summary
- publish executable regression coverage for the documented GNU Make trust boundaries
- align repository guidance with enforceable caller and startup boundaries

## Baseline
- later double-colon recipes, startup parse-time code, explicit overrides, and PATH-selected tools needed a precise documented ownership boundary

## Improvements
- add hosted regression coverage while keeping notebook, NOAA request behavior, dependencies, lockfiles, workflow, and scientific outputs unchanged

## Validation
- canonical and external-directory `make check` passed 27 unit tests and 20 notebook contracts at the pull-request head
- harmless probes reproduced the documented append and startup parse-time boundaries
- independent candidate review reported no blocking issue

## Risk
- the change defines build-system trust boundaries only and does not validate live NOAA behavior or alter dependency/runtime semantics

## Follow-Ups
- preserve the documented caller authority and Make startup boundary in future verification changes
