### PR TITLE
docs: document reproducible weather setup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,26 @@
 # Changes
 
+## 2026-06-26
+
+- Priority P2 cycle: completed the only explicit roadmap gap; no delegated
+  threads were started because the documentation and contract change was small
+  and isolated.
+- Documented reproducible virtual-environment setup with the matching Python
+  3.12 or 3.14 lockfile and an explicit import verification step.
+- Clarified that `requirements.txt` is lock-generation input, `uv` is needed
+  only for `make lock`, and the NOAA token is required only for live notebook
+  requests rather than offline verification.
+- Replaced stale generated repository inventory with the actual notebook,
+  helper, test, dependency, and verification surfaces and added fail-closed
+  documentation contracts.
+- Python 3.12.13 and 3.14.6 each passed hash-locked installation, scientific
+  imports, 27 offline tests, 21 static contracts, 40 Make authority cases, and
+  full checkout-local plus external-directory `make check` gates. Fourteen
+  hostile documentation and registration mutations were rejected.
+- No blocker remains. The next recommended action is to keep direct pins,
+  lockfiles, README guidance, and the hosted matrix synchronized whenever the
+  scientific environment changes.
+
 ## 2026-06-21
 
 - Isolated Make verification authority from caller-controlled roots, shells,

--- a/README.md
+++ b/README.md
@@ -5,44 +5,102 @@
 
 ## Overview
 
-`garethpaul/weather-notebooks` is a data science notebook project. Weather Notebooks
+`garethpaul/weather-notebooks` is a reproducible NOAA weather-data notebook and
+an importable set of request, validation, conversion, dataframe, and plotting
+helpers.
 
-This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: no dominant source language detected.
+The checked-in analysis uses a fixed historical station and date range. It does
+not provide current-weather conditions or a representative climate series.
 
 ## Repository Contents
 
-- `SECURITY.md` - security reporting and disclosure guidance
-- `VISION.md` - project direction and maintenance guardrails
-
-Additional scan context:
-
-- Source directories: no top-level source directories detected
-- Dependency and build manifests: none detected
-- Entry points or build surfaces: none detected
-- Test-looking files: no obvious test files detected
+- `Weather.ipynb` - the preserved interactive NOAA analysis
+- `weather_notebook.py` - reusable NOAA request and transformation helpers
+- `weather_notebook_tests.py` - dependency-aware offline behavior tests
+- `requirements.txt` - five exact direct dependency pins used as lock input
+- `requirements-py312.lock` and `requirements-py314.lock` - reviewed complete
+  Linux dependency graphs with SHA-256 hashes
+- `Makefile` and `scripts/` - canonical verification, lock generation, static
+  contracts, and Make authority tests
+- `SECURITY.md` and `VISION.md` - security and maintenance guardrails
 
 ## Getting Started
 
 ### Prerequisites
 
 - Git
-- Python 3
-- A NOAA Climate Data Online API token available as `NOAA_TOKEN`
+- CPython 3.12 or 3.14 with `venv` and pip
+- A NOAA Climate Data Online API token available as `NOAA_TOKEN` only when
+  running the live notebook
+
+The repository supports reproducible Linux x86_64 installs only for the two
+Python versions with reviewed lockfiles:
+
+- Python 3.12 uses `requirements-py312.lock`.
+- Python 3.14 uses `requirements-py314.lock`.
+
+Do not install `requirements.txt` directly for a reviewed environment. It is
+the five-package direct input to lock generation; the version-matched lockfile
+contains the complete transitive graph and required hashes. `uv` is required
+only to regenerate both lockfiles with `make lock`, not for normal setup.
+
+The direct dependency requirements are:
+
+- `jupyter==1.1.1`
+- `matplotlib==3.10.9`
+- `numpy==2.4.6`
+- `pandas==3.0.3`
+- `requests==2.34.2`
 
 ### Setup
 
 ```bash
 git clone https://github.com/garethpaul/weather-notebooks.git
 cd weather-notebooks
-python -m pip install --require-hashes -r requirements-py312.lock
-export NOAA_TOKEN=your-noaa-token
 ```
 
-The setup commands above are derived from repository files. Legacy mobile, Python, or JavaScript samples may require older SDKs or package versions than a modern workstation uses by default.
+Create exactly one of the following environments.
+
+#### Python 3.12
+
+```bash
+python3.12 -m venv .venv
+. .venv/bin/activate
+python -m pip install --require-hashes -r requirements-py312.lock
+```
+
+#### Python 3.14
+
+```bash
+python3.14 -m venv .venv
+. .venv/bin/activate
+python -m pip install --require-hashes -r requirements-py314.lock
+```
+
+Then verify the selected environment:
+
+```bash
+python -c "import jupyter, matplotlib, numpy, pandas, requests"
+make check
+```
+
+`NOAA_TOKEN` is not required for `make check`; the gate is offline and uses fake
+responses. Export the token only in the shell that launches a live notebook:
+
+```bash
+export NOAA_TOKEN=your-noaa-token
+jupyter notebook Weather.ipynb
+```
+
+If the selected interpreter is unavailable, install CPython 3.12 or 3.14 rather
+than applying the other lockfile to an unreviewed Python version. A different
+operating system or CPU architecture needs a separately generated and reviewed
+lockfile before the environment can be called reproducible.
 
 ## Running or Using the Project
 
-- Run `jupyter notebook Weather.ipynb` after installing dependencies and setting `NOAA_TOKEN`.
+- Run `jupyter notebook Weather.ipynb` after installing the matching lockfile
+  and setting `NOAA_TOKEN` in the launch shell.
 - The notebook fetches NOAA CDO observations for station `GHCND:US1CAMR0037` across the configured date range.
 - The station is the repository's original sample selection, and the fixed
   2019 range keeps the analysis bounded and historical. Neither is claimed as
@@ -88,6 +146,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   title and axis labels.
 - `make lock` regenerates reviewed Python 3.12 and 3.14 Linux lockfiles with
   SHA-256 hashes from the five direct pins in `requirements.txt`.
+- See `docs/plans/2026-06-26-readme-setup-and-dependencies.md` for the supported
+  interpreter, lock-selection, token, and lock-regeneration guidance.
 - Hosted installs use pip `--require-hashes` against the matrix-matched lock;
   the current 106-package graph returned no findings from the official OSV API.
 - Completed maintenance plans live under `docs/plans` and are checked by

--- a/VISION.md
+++ b/VISION.md
@@ -34,14 +34,11 @@ Priority:
 - Keep GitHub Actions running the offline `make check` baseline before review
 - Avoid presenting historical data as current conditions
 - Keep the scientific environment exactly pinned and import-verified in CI
+- Keep README setup and exact dependency requirements aligned with the supported lockfiles
 - Exercise the complete offline analysis flow from synthetic NOAA responses
   through dataframe construction and a headless average-temperature plot
 - Include NOAA source, station, historical range, UTC retrieval completion
   time, and display units in generated plot context
-
-Next priorities:
-
-- Add README setup notes and dependency requirements
 
 Contribution rules:
 

--- a/docs/plans/2026-06-26-readme-setup-and-dependencies.md
+++ b/docs/plans/2026-06-26-readme-setup-and-dependencies.md
@@ -1,0 +1,64 @@
+# README Setup And Dependency Requirements
+
+Status: Completed
+
+## Context
+
+The repository already maintained exact direct pins, reviewed hashed Python
+3.12 and 3.14 lockfiles, and a hosted install matrix, but the README described
+only generic Python 3 and always selected the Python 3.12 lock. It also treated
+the NOAA token as a setup requirement even though repository verification is
+offline.
+
+## Objectives
+
+- State that reproducible local environments use CPython 3.12 or 3.14.
+- Map each supported interpreter to its matching reviewed lockfile.
+- Bound the reviewed reproducible environment to Linux x86_64 and list all five
+  exact direct dependency requirements.
+- Create an isolated virtual environment, install with `--require-hashes`, and
+  verify the five scientific imports before running `make check`.
+- Explain that `requirements.txt` is direct lock input and must not replace a
+  complete lockfile for reviewed installs.
+- Keep `uv` optional for normal setup and require it only for `make lock`.
+- Separate offline verification from live NOAA requests and token handling.
+- Replace stale generated inventory with the repository's real notebook,
+  helper, test, dependency, and verification surfaces.
+
+## Verification
+
+- Focused README setup and dependency contract fails before documentation is
+  aligned and passes afterward.
+- Hostile interpreter, lock mapping, direct-requirements, uv, token, roadmap,
+  change-history, plan-status, and test-registration mutations fail closed.
+- `python3 scripts/check_weather_notebook_contracts.py`
+- `python3 -m unittest weather_notebook_tests`
+- `make check` from the checkout and through an absolute Makefile path from an
+  external working directory.
+- `git diff --check`
+
+## Scope Boundary
+
+- Do not change notebook behavior, request logic, data, dependencies, lockfile
+  contents, workflow behavior, or generated analysis outputs.
+- Do not require a NOAA token or network access for repository verification.
+- Do not claim reproducibility for a Python version without a reviewed lockfile
+  and hosted install proof.
+
+## Work Completed
+
+- Added exact Python 3.12 and 3.14 virtual-environment paths with matching
+  Linux x86_64 hashed lockfiles, direct pins, and import verification.
+- Distinguished direct lock input, complete lockfiles, normal setup, lock
+  regeneration, offline checks, and live token-bearing notebook execution.
+- Registered executable documentation and completed-plan contracts.
+
+## Results
+
+- Python 3.12.13 with `requirements-py312.lock` and Python 3.14.6 with
+  `requirements-py314.lock` both installed with `--require-hashes` and imported
+  Jupyter, Matplotlib, NumPy, pandas, and Requests.
+- Each environment passed checkout-local and external-directory `make check`,
+  including 27 offline tests, 21 static contracts, and 40 Make authority cases.
+- Fourteen hostile setup, platform, lock, pin, token, roadmap, history, plan,
+  and registration mutations failed closed.

--- a/scripts/check_weather_notebook_contracts.py
+++ b/scripts/check_weather_notebook_contracts.py
@@ -73,6 +73,9 @@ JUPYTERLAB_SECURITY_PLAN_PATH = (
 MAKE_AUTHORITY_PLAN_PATH = (
     ROOT / "docs" / "plans" / "2026-06-21-make-authority-isolation.md"
 )
+README_SETUP_PLAN_PATH = (
+    ROOT / "docs" / "plans" / "2026-06-26-readme-setup-and-dependencies.md"
+)
 CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "check.yml"
 LOCKFILE_SHA256 = {
     "requirements-py312.lock": "b59381ed41e79c40080b1ec5f772559bcc26bf33fa746e3d242304c24142fa4c",
@@ -568,6 +571,7 @@ def test_completed_plans_are_in_docs_plans():
     assert_completed_plan(STABLE_RESULT_COUNT_PLAN_PATH, "stable NOAA result count")
     assert_completed_plan(JUPYTERLAB_SECURITY_PLAN_PATH, "JupyterLab security update")
     assert_completed_plan(MAKE_AUTHORITY_PLAN_PATH, "Make authority isolation")
+    assert_completed_plan(README_SETUP_PLAN_PATH, "README setup and dependencies")
     checker_main = Path(__file__).read_text().rsplit("def main():", 1)[1]
     assert_true(
         "test_synthetic_analysis_flow_is_exercised," in checker_main,
@@ -580,6 +584,10 @@ def test_completed_plans_are_in_docs_plans():
     assert_true(
         "test_noaa_result_counts_remain_stable_across_pages," in checker_main,
         "stable NOAA result-count contract must run in the main suite",
+    )
+    assert_true(
+        "test_readme_setup_and_dependency_requirements," in checker_main,
+        "README setup and dependency contract must run in the main suite",
     )
 
 
@@ -838,6 +846,39 @@ def test_dependency_and_ci_contracts():
         assert_true(phrase in docs_text, "Make boundary documentation must include {0!r}".format(phrase))
 
 
+def test_readme_setup_and_dependency_requirements():
+    readme = " ".join((ROOT / "README.md").read_text().split())
+    vision = " ".join((ROOT / "VISION.md").read_text().split())
+    changes = " ".join((ROOT / "CHANGES.md").read_text().split())
+
+    for contract in (
+        "CPython 3.12 or 3.14",
+        "reproducible Linux x86_64 installs",
+        "requirements-py312.lock",
+        "requirements-py314.lock",
+        "python3.12 -m venv .venv",
+        "python3.14 -m venv .venv",
+        "Do not install `requirements.txt` directly for a reviewed environment",
+        "`uv` is required only to regenerate both lockfiles with `make lock`",
+        "`NOAA_TOKEN` is not required for `make check`",
+    ):
+        assert_true(contract in readme, "README setup guidance must include {0}".format(contract))
+    for requirement in (
+        line.strip()
+        for line in (ROOT / "requirements.txt").read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ):
+        assert_true("`{0}`".format(requirement) in readme, "README must list direct pin {0}".format(requirement))
+    assert_true(
+        "Keep README setup and exact dependency requirements aligned with the supported lockfiles" in vision,
+        "VISION must preserve setup and lockfile guidance",
+    )
+    assert_true(
+        "matching Python 3.12 or 3.14 lockfile" in changes,
+        "CHANGES must record supported lockfile selection",
+    )
+
+
 def main():
     tests = [
         test_noaa_token_comes_from_environment,
@@ -860,6 +901,7 @@ def main():
         test_synthetic_analysis_flow_is_exercised,
         test_analysis_provenance_is_visible_and_deterministic,
         test_dependency_and_ci_contracts,
+        test_readme_setup_and_dependency_requirements,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## Summary
- document reproducible Python 3.12 and 3.14 environments with matching Linux x86_64 hash-locked graphs
- distinguish direct pins, normal setup, lock regeneration, offline verification, and live NOAA token use

## Baseline
- setup guidance did not clearly separate reviewed hash-locked environments from lock input or credentialed live NOAA execution

## Improvements
- replace stale generated inventory, complete the README setup priority, and protect the guidance with executable contracts

## Validation
- focused setup contract failed before the README change and passed afterward
- 14 hostile interpreter, platform, lock, pin, uv, token, roadmap, history, plan, and registration mutations rejected
- Python 3.12 and 3.14 hash-locked installs and scientific imports passed
- checkout-local and external-directory `make check` passed 27 offline tests, 21 static contracts, and 40 Make authority cases

## Risk
- live NOAA requests remain unexecuted and require a user-supplied `NOAA_TOKEN`; the checked-in analysis is historical and not representative of current weather or climate

## Follow-Ups
- regenerate both reviewed lock graphs together when direct pins change and keep NOAA credentials out of git
